### PR TITLE
Force `BigEndianRead` trait to be sized.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -379,7 +379,7 @@ pub fn read_nfix<R>(rd: &mut R) -> Result<i8, FixedValueReadError>
     }
 }
 
-trait BigEndianRead {
+trait BigEndianRead: Sized {
     fn read<R: Read>(rd: &mut R) -> Result<Self, byteorder::Error>;
 }
 


### PR DESCRIPTION
Fixes #34.