### PR TITLE
misc(rmp): allow use of newer byteorder dep

### DIFF
--- a/rmp/Cargo.toml
+++ b/rmp/Cargo.toml
@@ -10,4 +10,4 @@ readme = "../README.md"
 keywords = ["msgpack", "MessagePack"]
 
 [dependencies]
-byteorder = "^0.3"
+byteorder = "^0.4"


### PR DESCRIPTION
Right now byteorder 0.4.2 appears to work fine without code changes.

And 0.3.x will (of course) continue to work.

We want to expand the allowed versions so users of this crate can avoid
pulling in (unneededly) multiple versions of the same create (byteorder
uses libc)

I've expanded the version match to allow any '0.*' version to avoid
repeating this commit in the future, but I'm OK if you'd like a more
restricted version (does cargo allow '<0.5 && >=0.3'?).