### PR TITLE
Made rmp-serde compatible with serde 0.7

### DIFF
--- a/rmp-serde/Cargo.toml
+++ b/rmp-serde/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["msgpack", "MessagePack", "serder", "serialization"]
 
 [dependencies]
 rmp = { version = "*", path = "../rmp" }
-serde = "^0.6"
-serde_macros = { version = "^0.6", optional = true }
+serde = "^0.7"
+serde_macros = { version = "^0.7", optional = true }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -30,7 +30,8 @@ pub enum Error {
     UnknownLength,
 
     /// Depth limit exceeded
-    DepthLimitExceeded
+    DepthLimitExceeded,
+    Custom(String)
 }
 
 impl ::std::error::Error for Error {
@@ -40,6 +41,7 @@ impl ::std::error::Error for Error {
             Error::InvalidValueWrite(..) => "invalid value write",
             Error::UnknownLength => "attempt to serialize struct, sequence or map with unknown length",
             Error::DepthLimitExceeded => "depth limit exceeded",
+            Error::Custom(_) => "custom message",
         }
     }
 
@@ -49,6 +51,7 @@ impl ::std::error::Error for Error {
             Error::InvalidValueWrite(ref err) => Some(err),
             Error::UnknownLength => None,
             Error::DepthLimitExceeded => None,
+            Error::Custom(_) => None,
         }
     }
 }
@@ -71,6 +74,13 @@ impl From<FixedValueWriteError> for Error {
 impl From<ValueWriteError> for Error {
     fn from(err: ValueWriteError) -> Error {
         Error::InvalidValueWrite(err)
+    }
+}
+
+impl serde::ser::Error for Error {
+    /// Raised when there is general error when deserializing a type.
+    fn custom<T: Into<String>>(msg: T) -> Error {
+        Error::Custom(msg.into())
     }
 }
 
@@ -162,78 +172,78 @@ impl<'a, W: VariantWriter> Serializer<'a, W> {
 impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
     type Error = Error;
 
-    fn visit_unit(&mut self) -> Result<(), Error> {
+    fn serialize_unit(&mut self) -> Result<(), Error> {
         write_nil(&mut self.wr).map_err(From::from)
     }
 
-    fn visit_bool(&mut self, val: bool) -> Result<(), Error> {
+    fn serialize_bool(&mut self, val: bool) -> Result<(), Error> {
         write_bool(&mut self.wr, val).map_err(From::from)
     }
 
-    fn visit_u8(&mut self, val: u8) -> Result<(), Error> {
-        self.visit_u64(val as u64)
+    fn serialize_u8(&mut self, val: u8) -> Result<(), Error> {
+        self.serialize_u64(val as u64)
     }
 
-    fn visit_u16(&mut self, val: u16) -> Result<(), Error> {
-        self.visit_u64(val as u64)
+    fn serialize_u16(&mut self, val: u16) -> Result<(), Error> {
+        self.serialize_u64(val as u64)
     }
 
-    fn visit_u32(&mut self, val: u32) -> Result<(), Error> {
-        self.visit_u64(val as u64)
+    fn serialize_u32(&mut self, val: u32) -> Result<(), Error> {
+        self.serialize_u64(val as u64)
     }
 
-    fn visit_u64(&mut self, val: u64) -> Result<(), Error> {
+    fn serialize_u64(&mut self, val: u64) -> Result<(), Error> {
         try!(write_uint(&mut self.wr, val));
 
         Ok(())
     }
 
-    fn visit_usize(&mut self, val: usize) -> Result<(), Error> {
-        self.visit_u64(val as u64)
+    fn serialize_usize(&mut self, val: usize) -> Result<(), Error> {
+        self.serialize_u64(val as u64)
     }
 
-    fn visit_i8(&mut self, val: i8) -> Result<(), Error> {
-        self.visit_i64(val as i64)
+    fn serialize_i8(&mut self, val: i8) -> Result<(), Error> {
+        self.serialize_i64(val as i64)
     }
 
-    fn visit_i16(&mut self, val: i16) -> Result<(), Error> {
-        self.visit_i64(val as i64)
+    fn serialize_i16(&mut self, val: i16) -> Result<(), Error> {
+        self.serialize_i64(val as i64)
     }
 
-    fn visit_i32(&mut self, val: i32) -> Result<(), Error> {
-        self.visit_i64(val as i64)
+    fn serialize_i32(&mut self, val: i32) -> Result<(), Error> {
+        self.serialize_i64(val as i64)
     }
 
-    fn visit_i64(&mut self, val: i64) -> Result<(), Error> {
+    fn serialize_i64(&mut self, val: i64) -> Result<(), Error> {
         try!(write_sint_eff(&mut self.wr, val));
 
         Ok(())
     }
 
-    fn visit_isize(&mut self, val: isize) -> Result<(), Error> {
-        self.visit_i64(val as i64)
+    fn serialize_isize(&mut self, val: isize) -> Result<(), Error> {
+        self.serialize_i64(val as i64)
     }
 
-    fn visit_f32(&mut self, val: f32) -> Result<(), Error> {
+    fn serialize_f32(&mut self, val: f32) -> Result<(), Error> {
         write_f32(&mut self.wr, val).map_err(From::from)
     }
 
-    fn visit_f64(&mut self, val: f64) -> Result<(), Error> {
+    fn serialize_f64(&mut self, val: f64) -> Result<(), Error> {
         write_f64(&mut self.wr, val).map_err(From::from)
     }
 
     // TODO: The implementation involves heap allocation and is unstable.
-    fn visit_char(&mut self, val: char) -> Result<(), Error> {
+    fn serialize_char(&mut self, val: char) -> Result<(), Error> {
         let mut buf = String::new();
         buf.push(val);
-        self.visit_str(&buf)
+        self.serialize_str(&buf)
     }
 
-    fn visit_str(&mut self, val: &str) -> Result<(), Error> {
+    fn serialize_str(&mut self, val: &str) -> Result<(), Error> {
         write_str(&mut self.wr, val).map_err(From::from)
     }
 
-    fn visit_unit_variant(&mut self,
+    fn serialize_unit_variant(&mut self,
                           _name: &str,
                           variant_index: usize,
                           _variant: &str) -> Result<(), Error>
@@ -242,7 +252,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         try!(write_array_len(&mut self.wr, 2));
 
         // Encode a value position...
-        try!(self.visit_usize(variant_index));
+        try!(self.serialize_usize(variant_index));
 
         // ... and its arguments length.
         try!(write_array_len(&mut self.wr, 0));
@@ -253,7 +263,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
     /// Encodes and attempts to write the enum value into the Write.
     ///
     /// Currently we encode variant types as a tuple of id with array of args, like: [id, [args...]]
-    fn visit_tuple_variant<V>(&mut self,
+    fn serialize_tuple_variant<V>(&mut self,
                               _name: &str,
                               variant_index: usize,
                               _variant: &str,
@@ -264,7 +274,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         try!(write_array_len(&mut self.wr, 2));
 
         // Encode a value position...
-        try!(self.visit_usize(variant_index));
+        try!(self.serialize_usize(variant_index));
 
         let len = match visitor.len() {
             Some(len) => len,
@@ -279,7 +289,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         Ok(())
     }
 
-    fn visit_struct_variant<V>(&mut self,
+    fn serialize_struct_variant<V>(&mut self,
                                _name: &str,
                                _variant_index: usize,
                                _variant: &str,
@@ -289,18 +299,18 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         unimplemented!()
     }
 
-    fn visit_none(&mut self) -> Result<(), Error> {
-        self.visit_unit()
+    fn serialize_none(&mut self) -> Result<(), Error> {
+        self.serialize_unit()
     }
 
-    fn visit_some<T>(&mut self, v: T) -> Result<(), Error>
+    fn serialize_some<T>(&mut self, v: T) -> Result<(), Error>
         where T: serde::Serialize,
     {
         depth_count!(self.depth, v.serialize(self))
     }
 
     // TODO: Check len, overflow is possible.
-    fn visit_seq<V>(&mut self, mut visitor: V) -> Result<(), Error>
+    fn serialize_seq<V>(&mut self, mut visitor: V) -> Result<(), Error>
         where V: serde::ser::SeqVisitor,
     {
         let len = match visitor.len() {
@@ -315,13 +325,13 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         Ok(())
     }
 
-    fn visit_seq_elt<V>(&mut self, value: V) -> Result<(), Error>
+    fn serialize_seq_elt<V>(&mut self, value: V) -> Result<(), Error>
         where V: serde::Serialize,
     {
         value.serialize(self)
     }
 
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<(), Error>
+    fn serialize_map<V>(&mut self, mut visitor: V) -> Result<(), Error>
         where V: serde::ser::MapVisitor,
     {
         let len = match visitor.len() {
@@ -336,7 +346,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         Ok(())
     }
 
-    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Error>
+    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Error>
         where K: serde::Serialize,
               V: serde::Serialize,
     {
@@ -344,13 +354,13 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         value.serialize(self)
     }
 
-    fn visit_unit_struct(&mut self, _name: &'static str) -> Result<(), Error> {
+    fn serialize_unit_struct(&mut self, _name: &'static str) -> Result<(), Error> {
         try!(write_array_len(&mut self.wr, 0));
 
         Ok(())
     }
 
-    fn visit_struct<V>(&mut self, _name: &str, mut visitor: V) -> Result<(), Error>
+    fn serialize_struct<V>(&mut self, _name: &str, mut visitor: V) -> Result<(), Error>
         where V: serde::ser::MapVisitor,
     {
         let len = match visitor.len() {
@@ -365,14 +375,14 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
         Ok(())
     }
 
-    fn visit_struct_elt<V>(&mut self, _key: &str, value: V) -> Result<(), Error>
+    fn serialize_struct_elt<V>(&mut self, _key: &str, value: V) -> Result<(), Error>
         where V: serde::Serialize,
     {
         try!(self.vw.write_field_name(&mut self.wr, _key));
         value.serialize(self)
     }
 
-    fn visit_bytes(&mut self, value: &[u8]) -> Result<(), Error> {
+    fn serialize_bytes(&mut self, value: &[u8]) -> Result<(), Error> {
         try!(write_bin_len(&mut self.wr, value.len() as u32));
         self.wr.write_all(value).map_err(|err| Error::InvalidValueWrite(ValueWriteError::InvalidDataWrite(WriteError(err))))
     }

--- a/rmp-serde/tests/de_macro.rs
+++ b/rmp-serde/tests/de_macro.rs
@@ -237,13 +237,13 @@ fn pass_enum_custom_policy() {
     impl<R: Read> serde::Deserializer for CustomDeserializer<R> {
         type Error = Error;
 
-        fn visit<V>(&mut self, visitor: V) -> Result<V::Value>
+        fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value>
             where V: serde::de::Visitor
         {
-            self.inner.visit(visitor)
+            self.inner.deserialize(visitor)
         }
 
-        fn visit_enum<V>(&mut self, _enum: &str, _variants: &'static [&'static str], mut visitor: V)
+        fn deserialize_enum<V>(&mut self, _enum: &str, _variants: &'static [&'static str], mut visitor: V)
             -> Result<V::Value>
             where V: serde::de::EnumVisitor
         {


### PR DESCRIPTION
I was trying to drop rmp-serde into a project where I was already using serde with serde-json, and discovered that it wouldn't work.  So, I updated rmp to work with the most recent version of serde (0.7).

Basically, it involved renaming a few things and adding in a couple of new error conditions.