### PR TITLE
Switch unit structs to using the same serialization mechanism as other structs

### DIFF
--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -361,7 +361,7 @@ impl<'a, W: VariantWriter> serde::Serializer for Serializer<'a, W> {
     }
 
     fn serialize_unit_struct(&mut self, _name: &'static str) -> Result<(), Error> {
-        try!(write_array_len(&mut self.wr, 0));
+        try!(self.vw.write_struct_len(&mut self.wr, 0));
 
         Ok(())
     }


### PR DESCRIPTION
Right now if there is a struct with no elements it's being serialized as an array, which is fine with the default way of handling structs, which is as an array.  If, however, you want to serialize a struct as a map (as I do) then this causes inconsistencies.