### PR TITLE
serde: Add convenience to_vec / from_slice (de)serialization functions.

### DIFF
--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -67,3 +67,21 @@ pub use encode::Serializer;
 
 pub mod decode;
 pub mod encode;
+
+/// Serializes a value to a byte vector.
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, encode::Error>
+        where T: serde::Serialize
+{
+    let mut buf = Vec::with_capacity(64);
+    value.serialize(&mut Serializer::new(&mut buf))
+         .and_then(|_| Ok(buf))
+}
+
+/// Deserializes a byte slice into the desired type.
+pub fn from_slice<T>(input: &[u8]) -> Result<T, decode::Error>
+        where T: serde::Deserialize
+{
+    let cur = std::io::Cursor::new(&input[..]);
+    let mut de = Deserializer::new(cur);
+    serde::Deserialize::deserialize(&mut de)
+}


### PR DESCRIPTION

This adds convenience to_vec() and from_slice() functions for rmp-serde.

The naming is in line with other serde modules (serde_json has to_string / from_str, and most other modules have something similar).

Now you can just do this:

```rust
let ser = rmp_serde::to_vec(&some_struct).unwrap();
let val = rmp_serde::from_slice::<MyType>(&ser).unwrap();
```