### PR TITLE
Fix build on nightly rustc

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -511,7 +511,7 @@ pub trait Read<'de>: io::Read {
     fn read_slice<'a>(&'a mut self, len: usize) -> Result<Reference<'de, 'a, [u8]>, io::Error>;
 }
 
-struct SliceReader<'a> {
+pub struct SliceReader<'a> {
     inner: &'a [u8],
 }
 


### PR DESCRIPTION
Hi.
https://github.com/rust-lang/rust/pull/42125 is going to fix some holes in `rustc`'s privacy checker.
Unfortunately, it can break code sometimes.
`crates.io` testing found 3 unexpected regressions, including this crate.
This PR updates the code to build successfully with https://github.com/rust-lang/rust/pull/42125