### PR TITLE
Switch to using char::encode_utf8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
 rust:
   - nightly
   - stable
-  - 1.13.0
+  - 1.16.0
+  - 1.17.0
 
 before_script:
   - |

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -327,10 +327,9 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        // TODO: The implementation involves heap allocation and is unstable.
-        let mut buf = String::new();
-        buf.push(v);
-        self.serialize_str(&buf)
+        // A char encoded as UTF-8 takes 4 bytes at most.
+        let mut buf = [0; 4];
+        self.serialize_str(v.encode_utf8(&mut buf))
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {

--- a/rmp-serialize/src/encode.rs
+++ b/rmp-serialize/src/encode.rs
@@ -97,9 +97,9 @@ impl<'a> rustc_serialize::Encoder for Encoder<'a> {
 
     // TODO: The implementation involves heap allocation and is unstable.
     fn emit_char(&mut self, val: char) -> Result<(), Error> {
-        let mut buf = String::new();
-        buf.push(val);
-        self.emit_str(&buf)
+        // A char encoded as UTF-8 takes 4 bytes at most.
+        let mut buf = [0; 4];
+        self.emit_str(val.encode_utf8(&mut buf))
     }
 
     fn emit_str(&mut self, val: &str) -> Result<(), Error> {


### PR DESCRIPTION
In Rust 1.15, the function `char::encode_utf8` was stabilized. Assuming
that rmp follows the serde standard of supporting the last 3 stable
releases, this function is now safe to use. I believe this removes the
last allocation required on the serialization path.