### PR TITLE
Add _named methods for serializing structs as maps

### DIFF
--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -158,12 +158,7 @@ impl<W: Write> Serializer<W, StructArrayWriter> {
     pub fn compact(wr: W) -> Self {
         Serializer::with(wr, StructArrayWriter)
     }
-}
 
-impl<W: Write> Serializer<W, StructMapWriter> {
-    pub fn named(wr: W) -> Self {
-        Serializer::with(wr, StructMapWriter)
-    }
 }
 
 impl<W: Write, V> Serializer<W, V> {
@@ -515,7 +510,7 @@ pub fn write_named<W: ?Sized, T: ?Sized>(wr: &mut W, val: &T) -> Result<(), Erro
     where W: Write,
           T: Serialize
 {
-    val.serialize(&mut Serializer::named(wr))
+    val.serialize(&mut Serializer::new_named(wr))
 }
 
 
@@ -545,6 +540,6 @@ pub fn to_vec_named<T>(value: &T) -> Result<Vec<u8>, Error>
     where T: serde::Serialize
 {
     let mut buf = Vec::with_capacity(64);
-    value.serialize(&mut Serializer::named(&mut buf))?;
+    value.serialize(&mut Serializer::new_named(&mut buf))?;
     Ok(buf)
 }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -92,6 +92,33 @@ impl VariantWriter for StructArrayWriter {
     }
 }
 
+pub struct StructMapWriter;
+
+impl VariantWriter for StructMapWriter {
+    fn write_struct_len<W>(&self, wr: &mut W, len: u32) -> Result<Marker, ValueWriteError>
+        where W: Write
+    {
+        write_map_len(wr, len)
+    }
+
+    fn write_field_name<W>(&self, wr: &mut W, key: &str) -> Result<(), ValueWriteError>
+        where W: Write
+    {
+        write_str(wr, key)
+    }
+}
+impl<W: Write> Serializer<W, StructMapWriter> {
+    /// Constructs a new `MessagePack` serializer whose output will be written to the writer
+    /// specified.
+    ///
+    /// # Note
+    ///
+    /// This is the default constructor, which returns a serializer that will serialize structs
+    /// using large named representation.
+    pub fn new_named(wr: W) -> Self {
+        Serializer::with(wr, StructMapWriter)
+    }
+}
 /// Represents MessagePack serialization implementation.
 ///
 /// # Note
@@ -127,6 +154,15 @@ impl<W: Write> Serializer<W, StructArrayWriter> {
     /// using compact tuple representation, without field names.
     pub fn new(wr: W) -> Self {
         Serializer::with(wr, StructArrayWriter)
+    }
+    pub fn compact(wr: W) -> Self {
+        Serializer::with(wr, StructArrayWriter)
+    }
+}
+
+impl<W: Write> Serializer<W, StructMapWriter> {
+    pub fn named(wr: W) -> Self {
+        Serializer::with(wr, StructMapWriter)
     }
 }
 
@@ -238,9 +274,10 @@ impl<'a, W: Write + 'a, V: VariantWriter + 'a> SerializeStruct for Compound<'a, 
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) ->
-        Result<(), Self::Error>
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self,
+                                              key: &'static str,
+                                              value: &T)
+                                              -> Result<(), Self::Error> {
         self.se.vw.write_field_name(&mut self.se.wr, key)?;
         value.serialize(&mut *self.se)
     }
@@ -254,9 +291,10 @@ impl<'a, W: Write + 'a, V: VariantWriter + 'a> SerializeStructVariant for Compou
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(&mut self, _key: &'static str, value: &T) ->
-        Result<(), Self::Error>
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self,
+                                              _key: &'static str,
+                                              value: &T)
+                                              -> Result<(), Self::Error> {
         value.serialize(&mut *self.se)
     }
 
@@ -363,21 +401,31 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
         Ok(())
     }
 
-    fn serialize_unit_variant(self, _name: &str, idx: u32, _variant: &str) ->
-        Result<Self::Ok, Self::Error>
-    {
+    fn serialize_unit_variant(self,
+                              _name: &str,
+                              idx: u32,
+                              _variant: &str)
+                              -> Result<Self::Ok, Self::Error> {
         write_array_len(&mut self.wr, 2)?;
         self.serialize_u32(idx)?;
         write_array_len(&mut self.wr, 0)?;
         Ok(())
     }
 
-    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(self, name: &'static str, value: &T) -> Result<(), Self::Error> {
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(self,
+                                                              name: &'static str,
+                                                              value: &T)
+                                                              -> Result<(), Self::Error> {
         self.serialize_tuple_struct(name, 1)?;
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(self, name: &'static str, variant_index: u32, variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error> {
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(self,
+                                                               name: &'static str,
+                                                               variant_index: u32,
+                                                               variant: &'static str,
+                                                               value: &T)
+                                                               -> Result<Self::Ok, Self::Error> {
         self.serialize_tuple_variant(name, variant_index, variant, 1)?;
         value.serialize(self)
     }
@@ -397,15 +445,19 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
         self.serialize_seq(Some(len))
     }
 
-    fn serialize_tuple_struct(self, _name: &'static str, len: usize) ->
-        Result<Self::SerializeTupleStruct, Self::Error>
-    {
+    fn serialize_tuple_struct(self,
+                              _name: &'static str,
+                              len: usize)
+                              -> Result<Self::SerializeTupleStruct, Self::Error> {
         self.serialize_tuple(len)
     }
 
-    fn serialize_tuple_variant(self,  name: &'static str,  idx: u32,  _variant: &'static str,  len: usize) ->
-        Result<Self::SerializeTupleVariant, Error>
-    {
+    fn serialize_tuple_variant(self,
+                               name: &'static str,
+                               idx: u32,
+                               _variant: &'static str,
+                               len: usize)
+                               -> Result<Self::SerializeTupleVariant, Error> {
         // We encode variant types as a tuple of id with array of args, like: [id, [args...]].
         rmp::encode::write_array_len(&mut self.wr, 2)?;
         self.serialize_u32(idx)?;
@@ -422,16 +474,20 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
         }
     }
 
-    fn serialize_struct(self, _name: &'static str, len: usize) ->
-        Result<Self::SerializeStruct, Self::Error>
-    {
+    fn serialize_struct(self,
+                        _name: &'static str,
+                        len: usize)
+                        -> Result<Self::SerializeStruct, Self::Error> {
         self.vw.write_struct_len(&mut self.wr, len as u32)?;
         Ok(Compound { se: self })
     }
 
-    fn serialize_struct_variant(self, name: &'static str, id: u32, _variant: &'static str, len: usize) ->
-        Result<Self::SerializeStructVariant, Error>
-    {
+    fn serialize_struct_variant(self,
+                                name: &'static str,
+                                id: u32,
+                                _variant: &'static str,
+                                len: usize)
+                                -> Result<Self::SerializeStructVariant, Error> {
         write_array_len(&mut self.wr, 2)?;
         self.serialize_u32(id)?;
         self.serialize_struct(name, len)
@@ -439,6 +495,7 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
 }
 
 /// Serialize the given data structure as MessagePack into the I/O stream.
+/// This fyunction uses compact representation - structures as arrays
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
 #[inline]
@@ -446,11 +503,28 @@ pub fn write<W: ?Sized, T: ?Sized>(wr: &mut W, val: &T) -> Result<(), Error>
     where W: Write,
           T: Serialize
 {
-    val.serialize(&mut Serializer::new(wr))
+    val.serialize(&mut Serializer::compact(wr))
+}
+
+/// Serialize the given data structure as MessagePack into the I/O stream.
+/// This function serializes structures as maps
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
+#[inline]
+pub fn write_named<W: ?Sized, T: ?Sized>(wr: &mut W, val: &T) -> Result<(), Error>
+    where W: Write,
+          T: Serialize
+{
+    val.serialize(&mut Serializer::named(wr))
 }
 
 
+
+
+
+
 /// Serialize the given data structure as a MessagePack byte vector.
+/// This method uses compact representation, structs are serialized as arrays
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
 #[inline]
@@ -459,5 +533,18 @@ pub fn to_vec<T: ?Sized>(val: &T) -> Result<Vec<u8>, Error>
 {
     let mut buf = Vec::with_capacity(128);
     write(&mut buf, val)?;
+    Ok(buf)
+}
+
+/// Serializes data structure into byte vector as a map
+/// Resulting MessagePack message will contain field names
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
+#[inline]
+pub fn to_vec_named<T>(value: &T) -> Result<Vec<u8>, Error>
+    where T: serde::Serialize
+{
+    let mut buf = Vec::with_capacity(64);
+    value.serialize(&mut Serializer::named(&mut buf))?;
     Ok(buf)
 }

--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -269,19 +269,8 @@ impl<'de> Deserialize<'de> for RawRef<'de> {
     }
 }
 
-/// Serializes a value to a byte vector.
-pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, encode::Error>
-    where T: serde::Serialize
-{
-    let mut buf = Vec::with_capacity(64);
-    value.serialize(&mut Serializer::new(&mut buf))?;
-    Ok(buf)
-}
+// Reexport common functions from encode module
+pub use encode::{write, write_named, to_vec, to_vec_named};
+// Reexport common functions from decode module
+pub use decode::{from_slice,from_read};
 
-/// Deserializes a byte slice into the desired type.
-pub fn from_slice<'a, T>(input: &'a [u8]) -> Result<T, decode::Error>
-    where T: serde::Deserialize<'a>
-{
-    let mut de = Deserializer::from_slice(input);
-    serde::Deserialize::deserialize(&mut de)
-}

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -34,7 +34,7 @@ fn round_trip_cow() {
         v: Cow<'a, [u8]>,
     }
 
-    let expected = Foo { v : Cow::Borrowed(&[]) };
+    let expected = Foo { v: Cow::Borrowed(&[]) };
 
     let mut buf = Vec::new();
     expected.serialize(&mut Serializer::new(&mut buf)).unwrap();
@@ -55,7 +55,7 @@ fn round_trip_option_cow() {
         v: Option<Cow<'a, [u8]>>,
     }
 
-    let expected = Foo { v : None };
+    let expected = Foo { v: None };
 
     let mut buf = Vec::new();
     expected.serialize(&mut Serializer::new(&mut buf)).unwrap();
@@ -85,4 +85,42 @@ fn round_enum_with_nested_struct() {
     let mut de = Deserializer::new(&buf[..]);
 
     assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
+}
+
+// Checks whether deserialization and serialization can both work with structs as maps
+#[test]
+fn round_struct_as_map() {
+
+
+    use std::io::Write;
+    use rmp::Marker;
+    use rmps::to_vec_named;
+    use rmps::decode::{from_read, from_slice};
+
+    #[derive(Debug,Serialize,Deserialize,PartialEq,Eq)]
+    struct Dog1 {
+        name: String,
+        age: u16,
+    }
+    #[derive(Debug,Serialize,Deserialize,PartialEq,Eq)]
+    struct Dog2 {
+        age: u16,
+        name: String,
+    }
+
+    let dog1 = Dog1 {
+        name: "Frankie".into(),
+        age: 42,
+    };
+
+    let mut serialized: Vec<u8> = to_vec_named(&dog1).unwrap();
+    let mut deserialized: Dog2 = from_slice(&serialized).unwrap();
+
+    let check = Dog1 {
+        age: deserialized.age,
+        name: deserialized.name,
+    };
+
+    assert_eq!(dog1, check);
+
 }


### PR DESCRIPTION
Hello, first PR :).
I had a problem with rmp-serde serializing structs as arrays so I added methods with _named suffix that would fix this. I also removed utlity methods from lib.rs and added reexports from encode.rs and decode.rs, since those methods were exactly same

Sorry for all the formatting spam. 
