### PR TITLE
feat: Add as_ref() to Value and Utf8String

### DIFF
--- a/rmpv/tests/decode_ref.rs
+++ b/rmpv/tests/decode_ref.rs
@@ -687,4 +687,5 @@ fn into_owned() {
     ]);
 
     assert_eq!(expected, val.to_owned());
+    assert_eq!(expected.as_ref(), val);
 }


### PR DESCRIPTION
Since `ValueRef` has a `to_owned()` method, it makes sense for `Value` to have an `as_ref()` method. 