### PR TITLE
Serialize struct as a map

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -606,3 +606,11 @@ pub fn from_read<R, T>(rd: R) -> Result<T, Error>
 {
     Deserialize::deserialize(&mut Deserializer::new(rd))
 }
+
+/// Deserializes a byte slice into the desired type.
+pub fn from_slice<'a, T>(input: &'a [u8]) -> Result<T, Error>
+    where T: serde::Deserialize<'a>
+{
+    let mut de = Deserializer::from_slice(input);
+    serde::Deserialize::deserialize(&mut de)
+}

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -520,3 +520,4 @@ where
     value.serialize(&mut Serializer::new_named(&mut buf))?;
     Ok(buf)
 }
+

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -92,6 +92,35 @@ impl VariantWriter for StructArrayWriter {
     }
 }
 
+pub struct StructMapWriter;
+
+impl VariantWriter for StructMapWriter {
+    fn write_struct_len<W>(&self, wr: &mut W, len: u32) -> Result<Marker, ValueWriteError>
+    where
+        W: Write,
+    {
+        write_map_len(wr, len)
+    }
+
+    fn write_field_name<W>(&self, wr: &mut W, key: &str) -> Result<(), ValueWriteError>
+    where
+        W: Write,
+    {
+        write_str(wr, key)
+    }
+}
+impl<W: Write> Serializer<W, StructMapWriter> {
+    /// Constructs a new `MessagePack` serializer whose output will be written to the writer
+    /// specified.
+    ///
+    /// # Note
+    ///
+    /// This is the default constructor, which returns a serializer that will serialize structs
+    /// using large named representation.
+    pub fn new_named(wr: W) -> Self {
+        Serializer::with(wr, StructMapWriter)
+    }
+}
 /// Represents MessagePack serialization implementation.
 ///
 /// # Note
@@ -127,6 +156,15 @@ impl<W: Write> Serializer<W, StructArrayWriter> {
     /// using compact tuple representation, without field names.
     pub fn new(wr: W) -> Self {
         Serializer::with(wr, StructArrayWriter)
+    }
+    pub fn compact(wr: W) -> Self {
+        Serializer::with(wr, StructArrayWriter)
+    }
+}
+
+impl<W: Write> Serializer<W, StructMapWriter> {
+    pub fn named(wr: W) -> Self {
+        Serializer::with(wr, StructMapWriter)
     }
 }
 
@@ -438,6 +476,7 @@ impl<'a, W: Write, V: VariantWriter> serde::Serializer for &'a mut Serializer<W,
 }
 
 /// Serialize the given data structure as MessagePack into the I/O stream.
+/// This fyunction uses compact representation - structures as arrays
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
 #[inline]
@@ -445,11 +484,24 @@ pub fn write<W: ?Sized, T: ?Sized>(wr: &mut W, val: &T) -> Result<(), Error>
     where W: Write,
           T: Serialize
 {
-    val.serialize(&mut Serializer::new(wr))
+    val.serialize(&mut Serializer::compact(wr))
 }
 
+/// Serialize the given data structure as MessagePack into the I/O stream.
+/// This function serializes structures as maps
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
+#[inline]
+pub fn write_named<W: ?Sized, T: ?Sized>(wr: &mut W, val: &T) -> Result<(), Error>
+where
+    W: Write,
+    T: Serialize,
+{
+    val.serialize(&mut Serializer::named(wr))
+}
 
 /// Serialize the given data structure as a MessagePack byte vector.
+/// This method uses compact representation, structs are serialized as arrays
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
 #[inline]
@@ -458,5 +510,19 @@ pub fn to_vec<T: ?Sized>(val: &T) -> Result<Vec<u8>, Error>
 {
     let mut buf = Vec::with_capacity(128);
     write(&mut buf, val)?;
+    Ok(buf)
+}
+
+/// Serializes data structure into byte vector as a map
+/// Resulting MessagePack message will contain field names
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to fail.
+#[inline]
+pub fn to_vec_named<T>(value: &T) -> Result<Vec<u8>, Error>
+where
+    T: serde::Serialize,
+{
+    let mut buf = Vec::with_capacity(64);
+    value.serialize(&mut Serializer::named(&mut buf))?;
     Ok(buf)
 }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -160,12 +160,7 @@ impl<W: Write> Serializer<W, StructArrayWriter> {
     pub fn compact(wr: W) -> Self {
         Serializer::with(wr, StructArrayWriter)
     }
-}
 
-impl<W: Write> Serializer<W, StructMapWriter> {
-    pub fn named(wr: W) -> Self {
-        Serializer::with(wr, StructMapWriter)
-    }
 }
 
 impl<W: Write, V> Serializer<W, V> {
@@ -497,7 +492,7 @@ where
     W: Write,
     T: Serialize,
 {
-    val.serialize(&mut Serializer::named(wr))
+    val.serialize(&mut Serializer::new_named(wr))
 }
 
 /// Serialize the given data structure as a MessagePack byte vector.
@@ -523,6 +518,6 @@ where
     T: serde::Serialize,
 {
     let mut buf = Vec::with_capacity(64);
-    value.serialize(&mut Serializer::named(&mut buf))?;
+    value.serialize(&mut Serializer::new_named(&mut buf))?;
     Ok(buf)
 }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -160,7 +160,6 @@ impl<W: Write> Serializer<W, StructArrayWriter> {
     pub fn compact(wr: W) -> Self {
         Serializer::with(wr, StructArrayWriter)
     }
-
 }
 
 impl<W: Write, V> Serializer<W, V> {

--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -269,19 +269,7 @@ impl<'de> Deserialize<'de> for RawRef<'de> {
     }
 }
 
-/// Serializes a value to a byte vector.
-pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, encode::Error>
-    where T: serde::Serialize
-{
-    let mut buf = Vec::with_capacity(64);
-    value.serialize(&mut Serializer::new(&mut buf))?;
-    Ok(buf)
-}
-
-/// Deserializes a byte slice into the desired type.
-pub fn from_slice<'a, T>(input: &'a [u8]) -> Result<T, decode::Error>
-    where T: serde::Deserialize<'a>
-{
-    let mut de = Deserializer::from_slice(input);
-    serde::Deserialize::deserialize(&mut de)
-}
+// Reexport common functions from encode module
+pub use encode::{write, write_named, to_vec, to_vec_named};
+// Reexport common functions from decode module
+pub use decode::{from_slice, from_read};

--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -68,8 +68,8 @@ use std::str::{self, Utf8Error};
 
 use serde::de::{self, Deserialize};
 
-pub use decode::Deserializer;
-pub use encode::Serializer;
+pub use decode::{Deserializer, from_slice, from_read};
+pub use encode::{Serializer, to_vec, to_vec_named};
 
 pub mod decode;
 pub mod encode;
@@ -268,8 +268,3 @@ impl<'de> Deserialize<'de> for RawRef<'de> {
         de.deserialize_any(RawRefVisitor)
     }
 }
-
-// Reexport common functions from encode module
-pub use encode::{write, write_named, to_vec, to_vec_named};
-// Reexport common functions from decode module
-pub use decode::{from_slice, from_read};

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -90,10 +90,8 @@ fn round_enum_with_nested_struct() {
 // Checks whether deserialization and serialization can both work with structs as maps
 #[test]
 fn round_struct_as_map() {
-    use std::io::Write;
-    use rmp::Marker;
     use rmps::to_vec_named;
-    use rmps::decode::{from_read, from_slice};
+    use rmps::decode::from_slice;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
     struct Dog1 {
@@ -111,8 +109,8 @@ fn round_struct_as_map() {
         age: 42,
     };
 
-    let mut serialized: Vec<u8> = to_vec_named(&dog1).unwrap();
-    let mut deserialized: Dog2 = from_slice(&serialized).unwrap();
+    let serialized: Vec<u8> = to_vec_named(&dog1).unwrap();
+    let deserialized: Dog2 = from_slice(&serialized).unwrap();
 
     let check = Dog1 {
         age: deserialized.age,

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -86,3 +86,38 @@ fn round_enum_with_nested_struct() {
 
     assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
 }
+
+// Checks whether deserialization and serialization can both work with structs as maps
+#[test]
+fn round_struct_as_map() {
+    use std::io::Write;
+    use rmp::Marker;
+    use rmps::to_vec_named;
+    use rmps::decode::{from_read, from_slice};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Dog1 {
+        name: String,
+        age: u16,
+    }
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Dog2 {
+        age: u16,
+        name: String,
+    }
+
+    let dog1 = Dog1 {
+        name: "Frankie".into(),
+        age: 42,
+    };
+
+    let mut serialized: Vec<u8> = to_vec_named(&dog1).unwrap();
+    let mut deserialized: Dog2 = from_slice(&serialized).unwrap();
+
+    let check = Dog1 {
+        age: deserialized.age,
+        name: deserialized.name,
+    };
+
+    assert_eq!(dog1, check);
+}


### PR DESCRIPTION
Revival of #133 
Related to #114 (or resolve it?), and [TODO comment](https://github.com/3Hren/msgpack-rust/blob/master/rmp-serde/src/encode.rs#L68)

I've excluded style-changing from #133 

This PR introduces `StructMapWriter` and its constructor, as discussed in https://github.com/3Hren/msgpack-rust/issues/114#issuecomment-286353371

cc: @semtexzv