### PR TITLE
Fix error when deserializing untagged enum

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -487,7 +487,7 @@ impl<'de, 'a, R: ReadSlice<'de>> de::VariantAccess<'de> for VariantAccess<'a, R>
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
-        decode::read_array_len(&mut self.de.rd)?;
+        decode::read_nil(&mut self.de.rd)?;
         Ok(())
     }
 

--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -364,8 +364,8 @@ impl<'de, 'a, R: ReadSlice<'de>> serde::Deserializer<'de> for &'a mut Deserializ
     fn deserialize_enum<V>(self, _name: &str, _variants: &[&str], visitor: V) -> Result<V::Value, Error>
         where V: Visitor<'de>
     {
-        match decode::read_array_len(&mut self.rd)? {
-            2 => visitor.visit_enum(VariantAccess::new(self)),
+        match decode::read_map_len(&mut self.rd)? {
+            1 => visitor.visit_enum(VariantAccess::new(self)),
             n => Err(Error::LengthMismatch(n as u32)),
         }
     }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -419,10 +419,10 @@ where
     fn serialize_unit_variant(self, _name: &str, idx: u32, _variant: &str) ->
         Result<Self::Ok, Self::Error>
     {
-         // encode as a map from variant idx to an empty array, like: {idx => []}
+        // encode as a map from variant idx to nil, like: {idx => nil}
         encode::write_map_len(&mut self.wr, 1)?;
         self.serialize_u32(idx)?;
-        encode::write_array_len(&mut self.wr, 0)?;
+        encode::write_nil(&mut self.wr).map_err(|e| Error::InvalidValueWrite(ValueWriteError::InvalidMarkerWrite(e)))?;
         Ok(())
     }
 

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -93,7 +93,9 @@ pub trait UnderlyingWrite {
 /// MessagePack has no specification about how to encode enum types. Thus we are free to do
 /// whatever we want, so the given chose may be not ideal for you.
 ///
-/// Every Rust enum value can be represented as a tuple of index with a value.
+/// An enum value is represented as a single-entry map whose key is the variant
+/// id and whose value is a sequence containing all associated data. If the enum
+/// does not have associated data, the sequence is empty.
 ///
 /// All instances of `ErrorKind::Interrupted` are handled by this function and the underlying
 /// operation is retried.
@@ -417,7 +419,8 @@ where
     fn serialize_unit_variant(self, _name: &str, idx: u32, _variant: &str) ->
         Result<Self::Ok, Self::Error>
     {
-        encode::write_array_len(&mut self.wr, 2)?;
+         // encode as a map from variant idx to an empty array, like: {idx => []}
+        encode::write_map_len(&mut self.wr, 1)?;
         self.serialize_u32(idx)?;
         encode::write_array_len(&mut self.wr, 0)?;
         Ok(())
@@ -429,7 +432,8 @@ where
     }
 
     fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(self, _name: &'static str, idx: u32, _variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error> {
-        encode::write_array_len(&mut self.wr, 2)?;
+        // encode as a map from variant idx to its attributed data, like: {idx => value}
+        encode::write_map_len(&mut self.wr, 1)?;
         self.serialize_u32(idx)?;
         value.serialize(self)
     }
@@ -458,8 +462,8 @@ where
     fn serialize_tuple_variant(self,  name: &'static str,  idx: u32,  _variant: &'static str,  len: usize) ->
         Result<Self::SerializeTupleVariant, Error>
     {
-        // We encode variant types as a tuple of id with array of args, like: [id, [args...]].
-        encode::write_array_len(&mut self.wr, 2)?;
+        // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
+        encode::write_map_len(&mut self.wr, 1)?;
         self.serialize_u32(idx)?;
         self.serialize_tuple_struct(name, len)
     }
@@ -484,7 +488,8 @@ where
     fn serialize_struct_variant(self, name: &'static str, id: u32, _variant: &'static str, len: usize) ->
         Result<Self::SerializeStructVariant, Error>
     {
-        encode::write_array_len(&mut self.wr, 2)?;
+        // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
+        encode::write_map_len(&mut self.wr, 1)?;
         self.serialize_u32(id)?;
         self.serialize_struct(name, len)
     }

--- a/rmp-serde/tests/decode_derive.rs
+++ b/rmp-serde/tests/decode_derive.rs
@@ -102,7 +102,7 @@ fn pass_struct_from_map() {
 
 #[test]
 fn pass_unit_variant() {
-    // We expect enums to be encoded as their variant idx
+    // We expect enums to be encoded as a map {variant_idx => nil}
 
     let buf = [0x81, 0x0, 0x90, 0x81, 0x1, 0x90];
     let cur = Cursor::new(&buf[..]);

--- a/rmp-serde/tests/decode_derive.rs
+++ b/rmp-serde/tests/decode_derive.rs
@@ -104,7 +104,7 @@ fn pass_struct_from_map() {
 fn pass_unit_variant() {
     // We expect enums to be encoded as a map {variant_idx => nil}
 
-    let buf = [0x81, 0x0, 0x90, 0x81, 0x1, 0x90];
+    let buf = [0x81, 0x0, 0xC0, 0x81, 0x1, 0xC0];
     let cur = Cursor::new(&buf[..]);
 
     #[derive(Debug, PartialEq, Deserialize)]

--- a/rmp-serde/tests/encode_derive.rs
+++ b/rmp-serde/tests/encode_derive.rs
@@ -32,8 +32,8 @@ fn pass_unit_variant() {
     Enum::V1.serialize(&mut Serializer::new(&mut buf)).unwrap();
     Enum::V2.serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: {0 => []} {1 => []}.
-    assert_eq!(vec![0x81, 0x00, 0x90, 0x81, 0x01, 0x90], buf);
+    // Expect: {0 => nil} {1 => nil}.
+    assert_eq!(vec![0x81, 0x00, 0xC0, 0x81, 0x01, 0xC0], buf);
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn pass_untagged_newtype_variant() {
     let buf2 = rmps::to_vec(&Enum1::B(Enum2::C)).unwrap();
 
     assert_eq!(buf1, [123]);
-    assert_eq!(buf2, [0x81, 0x0, 0x90]);
+    assert_eq!(buf2, [0x81, 0x0, 0xC0]);
 }
 
 #[test]
@@ -108,8 +108,8 @@ fn pass_tuple_variant() {
     Enum::V1.serialize(&mut Serializer::new(&mut buf)).unwrap();
     Enum::V2(42, 100500).serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: {0 => []} {1 => [42, 100500]}
-    assert_eq!(vec![0x81, 0x00, 0x90, 0x81, 0x01, 0x92, 0x2a, 0xce, 0x00, 0x01, 0x88, 0x94], buf);
+    // Expect: {0 => nil} {1 => [42, 100500]}
+    assert_eq!(vec![0x81, 0x00, 0xC0, 0x81, 0x01, 0x92, 0x2a, 0xce, 0x00, 0x01, 0x88, 0x94], buf);
 }
 
 #[test]

--- a/rmp-serde/tests/encode_derive.rs
+++ b/rmp-serde/tests/encode_derive.rs
@@ -32,8 +32,8 @@ fn pass_unit_variant() {
     Enum::V1.serialize(&mut Serializer::new(&mut buf)).unwrap();
     Enum::V2.serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: [0, []] [1, []].
-    assert_eq!(vec![0x92, 0x00, 0x90, 0x92, 0x01, 0x90], buf);
+    // Expect: {0 => []} {1 => []}.
+    assert_eq!(vec![0x81, 0x00, 0x90, 0x81, 0x01, 0x90], buf);
 }
 
 #[test]
@@ -58,8 +58,29 @@ fn pass_newtype_variant() {
     let mut buf = Vec::new();
     Enum::V2(42).serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: [0, 42].
-    assert_eq!(vec![0x92, 0x00, 0x2a], buf);
+    // Expect: {0 => 42}.
+    assert_eq!(vec![0x81, 0x00, 0x2a], buf);
+}
+
+#[test]
+fn pass_untagged_newtype_variant() {
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    enum Enum1 {
+        A(u64),
+        B(Enum2),
+    }
+
+    #[derive(Serialize)]
+    enum Enum2 {
+        C,
+    }
+
+    let buf1 = rmps::to_vec(&Enum1::A(123)).unwrap();
+    let buf2 = rmps::to_vec(&Enum1::B(Enum2::C)).unwrap();
+
+    assert_eq!(buf1, [123]);
+    assert_eq!(buf2, [0x81, 0x0, 0x90]);
 }
 
 #[test]
@@ -87,8 +108,8 @@ fn pass_tuple_variant() {
     Enum::V1.serialize(&mut Serializer::new(&mut buf)).unwrap();
     Enum::V2(42, 100500).serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: [0, []] [2, [42, 100500]].
-    assert_eq!(vec![0x92, 0x00, 0x90, 0x92, 0x01, 0x92, 0x2a, 0xce, 0x00, 0x01, 0x88, 0x94], buf);
+    // Expect: {0 => []} {1 => [42, 100500]}
+    assert_eq!(vec![0x81, 0x00, 0x90, 0x81, 0x01, 0x92, 0x2a, 0xce, 0x00, 0x01, 0x88, 0x94], buf);
 }
 
 #[test]
@@ -126,8 +147,8 @@ fn serialize_struct_variant() {
     Enum::V1 { f1: 42 }.serialize(&mut Serializer::new(&mut buf)).unwrap();
     Enum::V2 { f1: 43 }.serialize(&mut Serializer::new(&mut buf)).unwrap();
 
-    // Expect: [0, [42]] [1, [43]].
-    assert_eq!(vec![0x92, 0x00, 0x91, 0x2a, 0x92, 0x01, 0x91, 0x2b], buf);
+    // Expect: {0 => [42]} {1 => [43]}.
+    assert_eq!(vec![0x81, 0x00, 0x91, 0x2a, 0x81, 0x01, 0x91, 0x2b], buf);
 }
 
 #[test]

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -139,6 +139,8 @@ fn round_trip_untagged_enum_with_enum_associated_data() {
     let data3_2 = rmps::from_slice(&bytes_3).unwrap();
     assert_eq!(data3_1, data3_2);
 
+    // TODO: struct variants do not work yet because of a
+    // serde issue. A fix is pending (github.com/serde-rs/serde/pull/1093).
     // let data4_1 = Foo::A(Bar::E{f1: "Hello".into()});
     // let bytes_4 = rmps::to_vec(&data4_1).unwrap();
     // let data4_2 = rmps::from_slice(&bytes_4).unwrap();

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -87,11 +87,11 @@ fn round_enum_with_newtype_struct() {
 }
 
 #[test]
-fn round_trip_untagged() {
+fn round_trip_untagged_enum_with_enum_associated_data() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Zeb(Foo);
 
-    #[derive(Serialize, Debug, PartialEq)]
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     #[serde(untagged)]
     enum Foo {
         A(Bar),
@@ -100,27 +100,6 @@ fn round_trip_untagged() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     enum Bar {
         B{f1: String},
-    }
-
-    impl<'de> ::serde::Deserialize<'de> for Foo {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::serde::Deserializer<'de> {
-            use ::serde::de::Error;
-            use ::serde::private::de::{Content, ContentRefDeserializer};
-
-            let content = Content::deserialize(deserializer)?;
-
-            println!("B");
-            println!("{:?}", content);
-
-            let state = Bar::deserialize(ContentRefDeserializer::<D::Error>::new(&content));
-            println!("C");
-            println!("{:?}", state);
-            if let Ok(state) = state {
-                return Ok(Foo::A(state))
-            }
-            println!("D");
-            Err(D::Error::custom("data did not match any variant of untagged enum Foo"))
-        }
     }
 
     let data1 = Zeb(Foo::A(Bar::B{f1: "Hello".into()}));

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -99,10 +99,10 @@ fn round_trip_untagged_enum_with_enum_associated_data() {
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     enum Bar {
-        B{f1: String},
+        B(String),
     }
 
-    let data1 = Zeb(Foo::A(Bar::B{f1: "Hello".into()}));
+    let data1 = Zeb(Foo::A(Bar::B("Hello".into())));
     let bytes = rmps::to_vec(&data1).unwrap();
     let data2 = rmps::from_slice(&bytes).unwrap();
     assert_eq!(data1, data2);

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -88,10 +88,7 @@ fn round_enum_with_newtype_struct() {
 
 #[test]
 fn round_trip_untagged_enum_with_enum_associated_data() {
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Zeb(Foo);
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[derive(Serialize, Debug, PartialEq)]
     #[serde(untagged)]
     enum Foo {
         A(Bar),
@@ -99,13 +96,53 @@ fn round_trip_untagged_enum_with_enum_associated_data() {
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     enum Bar {
-        B(String),
+        B,
+        C(String),
+        D(u64, u64, u64),
+        E{f1: String},
     }
 
-    let data1 = Zeb(Foo::A(Bar::B("Hello".into())));
-    let bytes = rmps::to_vec(&data1).unwrap();
-    let data2 = rmps::from_slice(&bytes).unwrap();
-    assert_eq!(data1, data2);
+
+    impl<'de> ::serde::Deserialize<'de> for Foo {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::serde::Deserializer<'de> {
+            use ::serde::de::Error;
+            use ::serde::private::de::{Content, ContentRefDeserializer};
+
+            let content = Content::deserialize(deserializer)?;
+
+            println!("{:?}", content);
+
+            let state = Bar::deserialize(ContentRefDeserializer::<D::Error>::new(&content));
+            println!("{:?}", state);
+            if let Ok(state) = state {
+                return Ok(Foo::A(state))
+            }
+            Err(D::Error::custom("data did not match any variant of untagged enum Foo"))
+        }
+    }
+
+    let data1_1 = Foo::A(Bar::B);
+    let bytes_1 = rmps::to_vec(&data1_1).unwrap();
+
+    println!("{:?}", bytes_1);
+
+    let data1_2 = rmps::from_slice(&bytes_1).unwrap();
+    assert_eq!(data1_1, data1_2);
+
+    let data2_1 = Foo::A(Bar::C("Hello".into()));
+    let bytes_2 = rmps::to_vec(&data2_1).unwrap();
+    let data2_2 = rmps::from_slice(&bytes_2).unwrap();
+    assert_eq!(data2_1, data2_2);
+
+    let data3_1 = Foo::A(Bar::D(1,2,3));
+    let bytes_3 = rmps::to_vec(&data3_1).unwrap();
+    let data3_2 = rmps::from_slice(&bytes_3).unwrap();
+    assert_eq!(data3_1, data3_2);
+
+    // let data4_1 = Foo::A(Bar::E{f1: "Hello".into()});
+    // let bytes_4 = rmps::to_vec(&data4_1).unwrap();
+    // let data4_2 = rmps::from_slice(&bytes_4).unwrap();
+    // assert_eq!(data4_1, data4_2);
 }
 
 // Checks whether deserialization and serialization can both work with structs as maps


### PR DESCRIPTION
Deserialization fails whenever one enum is inside another untagged enum (see #148 for details). The root problem is that untagged deserialization uses `ContentDeserializer` and `ContentRefDeserializer`, which have unmet expectations:

1. A Unit variant is encoded either as a string or as a map from variant type to `unit`
2. A Tuple, NewType, or Struct variant is encoded as a map from variant type to associated data
3. A Struct variant's associated data must be encoded as a map

This PR fixes problems 1 and 2. A sibling PR on serde (https://github.com/serde-rs/serde/pull/1093)  fixes problem 3 by allowing sequence-encoded associated data for struct variants. As far as I can tell, there is no way to fix problem 3 without touching serde.

**Problem 1 Fix:** Update unit variant encoding from `[variant_idx, []]` to `{variant_idx => ()}`

**Problem 2 Fix:** Update tuple, newtype, and struct variant encoding from `[variant_idx, associated_data]` to `{variant_idx => associated_data}`.