### PR TITLE
Support for non utf-8 characters in the String

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -217,9 +217,13 @@ impl<'de, R: ReadSlice<'de>> Deserializer<R> {
         let unsafe_utf8 = self.use_unsafe_utf8;
         match self.read_bin_data(len as u32)? {
             Reference::Borrowed(buf) => {
+                //println!("Reference::Borrowed(buf):{:?}", buf);
                 let res = if unsafe_utf8 {Ok(unsafe{str::from_utf8_unchecked(buf)})} else {str::from_utf8(buf)};
                 match res {
-                    Ok(s) => visitor.visit_borrowed_str(s),
+                    Ok(s) => {
+                         //println!("Reference::Borrowed(s):{:?}", s);
+                        visitor.visit_borrowed_str(s)
+                    },
                     Err(err) => {
                         // Allow to unpack invalid UTF-8 bytes into a byte array.
                         match visitor.visit_borrowed_bytes::<Error>(buf) {
@@ -231,9 +235,13 @@ impl<'de, R: ReadSlice<'de>> Deserializer<R> {
             }
 
             Reference::Copied(buf) => {
+                //println!("Reference::Borrowed(buf):{:?}", buf);
                 let res = if unsafe_utf8 {Ok(unsafe{str::from_utf8_unchecked(buf)})} else {str::from_utf8(buf)};
                 match res {
-                    Ok(s) => visitor.visit_str(s),
+                    Ok(s) =>{
+                        //println!("Reference::Borrowed(s):{:?}", s);
+                         visitor.visit_str(s)
+                    },
                     Err(err) => {
                         // Allow to unpack invalid UTF-8 bytes into a byte array.
                         match visitor.visit_bytes::<Error>(buf) {


### PR DESCRIPTION
This PR optionally supports the non utf-8 characters in the Rust String.  

I tried to deserialize below serialized byte array payload from Lua  (https://github.com/antirez/lua-cmsgpack) and tried to deserialized using rust but getting  utf-8 errors.
``` 
[131 161 107 162 49 57 161 99 218 0 32 134 179 138 155 218 27 113 238 89 109 203 139 116 250 223 40 118 216 67 87 10 83 203 78 87 156 18 90 225 194 75 0    161 105 176 175 113 141 246 168 180 145 224 183 4 236 38 128 179 176 21]
```

This PR allows a new constructor with a flag to use an unsafe version of `str::from_utf8_unchecked` to allow binary characters in the string.

This may not be the right way to add the support but would love to have similar capability.