### PR TITLE
fix: weaken cursor restrictions in tests

### DIFF
--- a/rmp/src/decode/str.rs
+++ b/rmp/src/decode/str.rs
@@ -107,7 +107,7 @@ fn read_str_len_with_nread<R>(rd: &mut R) -> Result<(u32, usize), ValueReadError
 ///
 /// This function is **unstable**, because it needs review.
 // TODO: Stabilize. Mark error values for each error case (in docs).
-pub fn read_str<'r, R>(rd: &mut R, mut buf: &'r mut [u8]) -> Result<&'r str, DecodeStringError<'r>>
+pub fn read_str<'r, R>(rd: &mut R, buf: &'r mut [u8]) -> Result<&'r str, DecodeStringError<'r>>
     where R: Read
 {
     let len = try!(read_str_len(rd));

--- a/rmp/tests/func/decode/array.rs
+++ b/rmp/tests/func/decode/array.rs
@@ -48,7 +48,7 @@ fn from_array16_unexpected_eof_read_size() {
     let mut cur = Cursor::new(buf);
 
     read_array_len(&mut cur).err().unwrap();
-    assert_eq!(2, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn from_array32_unexpected_eof_read_size() {
     let mut cur = Cursor::new(buf);
 
     read_array_len(&mut cur).err().unwrap();
-    assert_eq!(4, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]

--- a/rmp/tests/func/decode/sint.rs
+++ b/rmp/tests/func/decode/sint.rs
@@ -108,7 +108,7 @@ fn from_i16_unexpected_eof() {
     let mut cur = Cursor::new(&buf[..]);
 
     read_i16(&mut cur).err().unwrap();
-    assert_eq!(2, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn from_i32_unexpected_eof() {
     let mut cur = Cursor::new(&buf[..]);
 
     read_i32(&mut cur).err().unwrap();
-    assert_eq!(4, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]
@@ -186,7 +186,7 @@ fn from_i64_unexpected_eof() {
     let mut cur = Cursor::new(&buf[..]);
 
     read_i64(&mut cur).err().unwrap();
-    assert_eq!(8, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]

--- a/rmp/tests/func/decode/string.rs
+++ b/rmp/tests/func/decode/string.rs
@@ -90,7 +90,7 @@ fn from_str16_read_str_len_eof() {
     let mut cur = Cursor::new(buf);
 
     read_str_len(&mut cur).err().unwrap();
-    assert_eq!(2, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn from_str32_read_str_len_eof() {
     let mut cur = Cursor::new(buf);
 
     read_str_len(&mut cur).err().unwrap();
-    assert_eq!(4, cur.position());
+    assert!(cur.position() >= 1);
 }
 
 #[test]


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust/issues/47640.
Closes #157.