### PR TITLE
[WIP] Provide blanket From impls for homogeneous collections

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Debug, Display};
 use std::ops::Index;
 use std::str::Utf8Error;
+use std::iter::FromIterator;
 
 use num_traits::NumCast;
 
@@ -994,6 +995,17 @@ impl From<Vec<(Value, Value)>> for Value {
     }
 }
 
+/// Note that an `Iterator<Item = u8>` will be collected into an
+/// [`Array`](crate::Value::Array), rather than a
+/// [`Binary`](crate::Value::Binary)
+impl<V> FromIterator<V> for Value 
+where V: Into<Value> {
+  fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+    let v: Vec<Value> = iter.into_iter().map(|v| v.into()).collect();
+    Value::Array(v)
+  }
+}
+
 impl Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
@@ -1255,6 +1267,17 @@ impl<'a> From<Vec<ValueRef<'a>>> for ValueRef<'a> {
     fn from(v: Vec<ValueRef<'a>>) -> Self {
         ValueRef::Array(v)
     }
+}
+
+/// Note that an `Iterator<Item = u8>` will be collected into an
+/// [`Array`](crate::Value::Array), rather than a
+/// [`Binary`](crate::Value::Binary)
+impl<'a, V> FromIterator<V> for ValueRef<'a>
+where V: Into<ValueRef<'a>> {
+  fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+    let v: Vec<ValueRef<'a>> = iter.into_iter().map(|v| v.into()).collect();
+    ValueRef::Array(v)
+  }
 }
 
 impl<'a> From<Vec<(ValueRef<'a>, ValueRef<'a>)>> for ValueRef<'a> {

--- a/rmpv/tests/value.rs
+++ b/rmpv/tests/value.rs
@@ -123,6 +123,24 @@ fn from_f64() {
 }
 
 #[test]
+fn from_iterator() {
+    let v: Vec<u8> = vec![0u8, 1u8, 2u8];
+    let w: Value = v.into_iter().collect();
+
+    let w2 = Value::Array(vec![
+                         Value::from(0u8),
+                         Value::from(1u8),
+                         Value::from(2u8)
+                         ]); 
+
+    assert_eq!(w, w2);
+
+    let w3 = Value::Binary(vec![0u8, 1u8, 2u8]);
+
+    assert!(w != w3);
+}
+
+#[test]
 fn is_nil() {
     assert!(Value::Nil.is_nil());
     assert!(!Value::Boolean(true).is_nil());


### PR DESCRIPTION
First shot at https://github.com/3Hren/msgpack-rust/issues/167.

This creates a wrapper type (all names non-final, of course) together with a `From` impl for `Value`. If this is done, we should make all function that take a `Value` take a `T: Into<Value>` instead, so we can directly pass the wrapper type instead having to call `.into()` on it beforehand.

This is a non-breaking change as far as I can see.

I've not connected all the dots, I wanted to hear what you think. I'll offer another alternative at the issue I opened.