### PR TITLE
feat: add ext encoder for encoding enum variant names as strings

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -565,11 +565,7 @@ impl<'de, 'a, R: ReadSlice<'de>> de::EnumAccess<'de> for VariantAccess<'a, R> {
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Error>
         where V: de::DeserializeSeed<'de>,
     {
-        use serde::de::IntoDeserializer;
-
-        let idx: u32 = serde::Deserialize::deserialize(&mut *self.de)?;
-        let val: Result<_, Error> = seed.deserialize(idx.into_deserializer());
-        Ok((val?, self))
+        Ok((seed.deserialize(&mut *self.de)?, self))
     }
 }
 

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -12,7 +12,9 @@ use serde::ser::{SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVar
 use rmp::encode;
 use rmp::encode::ValueWriteError;
 
-use ext::{StructMapSerializer, StructTupleSerializer};
+use ext::{
+    StructMapSerializer, StructTupleSerializer, VariantIntegerSerializer, VariantStringSerializer,
+};
 
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing MessagePack data.
@@ -197,6 +199,23 @@ pub trait Ext: UnderlyingWrite + Sized {
     /// representation.
     fn with_struct_tuple(self) -> StructTupleSerializer<Self> {
         StructTupleSerializer::new(self)
+    }
+
+    /// Consumes this serializer returning the new one which will serialize enum variants as strings.
+    ///
+    /// This is used when you the default variant serialization as integers does not fit your
+    /// requirements.
+    fn with_string_variants(self) -> VariantStringSerializer<Self> {
+        VariantStringSerializer::new(self)
+    }
+
+    /// Consumes this serializer returning the new one which will serialize enum variants as their
+    /// integer indices.
+    ///
+    /// This is the default MessagePack serialization mechanism emitting the most compact
+    /// representation.
+    fn with_integer_variants(self) -> VariantIntegerSerializer<Self> {
+        VariantIntegerSerializer::new(self)
     }
 }
 

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -186,6 +186,9 @@ impl<'a, W: Write + 'a> Serializer<W> {
 pub trait Ext: UnderlyingWrite + Sized {
     /// Consumes this serializer returning the new one, which will serialize structs as a map.
     ///
+    /// Note that this should always be applied before `with_string_variants` or `with_integer_variants`.
+    /// If this is applied after, it will clobber some of the modifications those make.
+    ///
     /// This is used, when you the default struct serialization as a tuple does not fit your
     /// requirements.
     fn with_struct_map(self) -> StructMapSerializer<Self> {
@@ -195,6 +198,9 @@ pub trait Ext: UnderlyingWrite + Sized {
     /// Consumes this serializer returning the new one, which will serialize structs as a tuple
     /// without field names.
     ///
+    /// Note that this should always be applied before `with_string_variants` or `with_integer_variants`.
+    /// If this is applied after, it will clobber some of the modifications those make.
+    ///
     /// This is the default MessagePack serialization mechanism, emitting the most compact
     /// representation.
     fn with_struct_tuple(self) -> StructTupleSerializer<Self> {
@@ -202,6 +208,10 @@ pub trait Ext: UnderlyingWrite + Sized {
     }
 
     /// Consumes this serializer returning the new one which will serialize enum variants as strings.
+    ///
+    /// Note this must be used after `with_struct_map` or `with_struct_tuple`. This plays nicely and
+    /// will correctly forward to `struct_map` modifications, but `struct_map` will clobber this method's
+    /// behavior if applied afterwards.
     ///
     /// This is used when you the default variant serialization as integers does not fit your
     /// requirements.

--- a/rmp-serde/src/ext.rs
+++ b/rmp-serde/src/ext.rs
@@ -531,7 +531,8 @@ where
 ///
 /// use std::collections::HashMap;
 ///
-/// use rmp_serde::{encode::Ext, Deserializer, Serializer};
+/// use rmp_serde::encode::Ext;
+/// use rmp_serde::{Deserializer, Serializer};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -715,8 +716,8 @@ where
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_str(variant)?;
-        self.serialize_unit()
+        self.se.serialize_str(variant)?;
+        self.se.serialize_unit()
     }
 
     #[inline]
@@ -743,8 +744,8 @@ where
         T: Serialize,
     {
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_str(variant)?;
-        self.serialize_newtype_struct(name, value)
+        self.se.serialize_str(variant)?;
+        self.se.serialize_newtype_struct(name, value)
     }
 
     #[inline]
@@ -776,9 +777,8 @@ where
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_str(variant)?;
-        self.serialize_tuple_struct(name, len)
-            .map(VariantForwardSerializer)
+        self.se.serialize_str(variant)?;
+        self.se.serialize_tuple_struct(name, len).map(VariantForwardSerializer)
     }
 
     #[inline]
@@ -805,9 +805,8 @@ where
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_str(variant)?;
-        self.serialize_struct(name, len)
-            .map(VariantForwardSerializer)
+        self.se.serialize_str(variant)?;
+        self.se.serialize_struct(name, len).map(VariantForwardSerializer)
     }
 }
 
@@ -969,8 +968,8 @@ where
         _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_u32(variant_index)?;
-        self.serialize_unit()
+        self.se.serialize_u32(variant_index)?;
+        self.se.serialize_unit()
     }
 
     #[inline]
@@ -996,8 +995,7 @@ where
     where
         T: Serialize,
     {
-        self.se
-            .serialize_newtype_variant(name, variant_index, variant, value)
+        self.se.serialize_newtype_variant(name, variant_index, variant, value)
     }
 
     #[inline]
@@ -1028,9 +1026,8 @@ where
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_u32(variant_index)?;
-        self.serialize_tuple_struct(name, len)
-            .map(VariantForwardSerializer)
+        self.se.serialize_u32(variant_index)?;
+        self.se.serialize_tuple_struct(name, len).map(VariantForwardSerializer)
     }
 
     #[inline]
@@ -1057,9 +1054,8 @@ where
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
         encode::write_map_len(self.se.get_mut(), 1)?;
-        self.serialize_u32(variant_index)?;
-        self.serialize_struct(name, len)
-            .map(VariantForwardSerializer)
+        self.se.serialize_u32(variant_index)?;
+        self.se.serialize_struct(name, len).map(VariantForwardSerializer)
     }
 }
 

--- a/rmp-serde/src/ext.rs
+++ b/rmp-serde/src/ext.rs
@@ -519,6 +519,49 @@ where
 ///
 /// Default `Serializer` implementation writes enum variants as integers, because it is the most compact
 /// representation.
+///
+/// Example using this serializer and `StructMapSerializer` to write a messagepack message using both
+/// field names and enum variant names rather than indices.
+///
+/// ```
+/// extern crate serde;
+/// #[macro_use]
+/// extern crate serde_derive;
+/// extern crate rmp_serde;
+///
+/// use std::collections::HashMap;
+///
+/// use rmp_serde::{encode::Ext, Deserializer, Serializer};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, PartialEq, Deserialize, Serialize)]
+/// enum Employment {
+///     Intern,
+///     FullTime,
+/// }
+///
+/// #[derive(Debug, PartialEq, Deserialize, Serialize)]
+/// struct Human {
+///     age: u32,
+///     name: String,
+///     employment: Employment,
+/// }
+///
+/// fn main() {
+///     let mut buf = Vec::new();
+///     let val = Human {
+///         age: 42,
+///         name: "John".into(),
+///         employment: Employment::Intern,
+///     };
+///     val.serialize(
+///        &mut Serializer::new(&mut buf)
+///            .with_struct_map()
+///            .with_string_variants(),
+///    )
+///    .unwrap();
+/// }
+/// ```
 #[derive(Debug)]
 pub struct VariantStringSerializer<S> {
     se: S,

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -329,11 +329,11 @@ fn round_variant_string() {
         (animal1).serialize(&mut Serializer::new(&mut buf).with_string_variants()).unwrap();
         buf
     };
-    let deserialized: Animal2  = from_slice(&serialized).unwrap();
+    let deserialized: Animal2 = from_slice(&serialized).unwrap();
 
     let check = match deserialized {
         Animal2::Emu => Animal1::Emu,
-        Animal2::Dog { breed } => Animal1::Dog { breed },
+        Animal2::Dog { breed } => Animal1::Dog { breed: breed },
         Animal2::Cat => Animal1::Cat,
     };
 

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -300,3 +300,42 @@ fn round_trip_unit_struct_untagged_enum() {
         assert_eq!(deserialized, msga);
     }
 }
+
+// Checks whether deserialization and serialization can both work with enum variants as strings
+#[test]
+fn round_variant_string() {
+    use rmps::decode::from_slice;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    enum Animal1 {
+        Dog { breed: String },
+        Cat,
+        Emu,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    enum Animal2 {
+        Emu,
+        Dog { breed: String },
+        Cat,
+    }
+
+    let animal1 = Animal1::Dog {
+        breed: "Pitbull".into()
+    };
+
+    let serialized: Vec<u8> = {
+        let mut buf = Vec::new();
+        (animal1).serialize(&mut Serializer::new(&mut buf).with_string_variants()).unwrap();
+        buf
+    };
+    let deserialized: Animal2  = from_slice(&serialized).unwrap();
+
+    let check = match deserialized {
+        Animal2::Emu => Animal1::Emu,
+        Animal2::Dog { breed } => Animal1::Dog { breed },
+        Animal2::Cat => Animal1::Cat,
+    };
+
+    assert_eq!(animal1, check);
+}


### PR DESCRIPTION
Edit: As of 2019-06-20, I've made some edits to this PR, and rewritten the main description. Original description is collapsed below. 


This adds `VariantStringSerializer` and `VariantIntegerSerializer` to modify the encoding of enum variants similar to how the current `StructMapSerializer` and `StructTupleSerializer` behave.

The serializer code itself should be pretty straightforward. Each new serializer forwards all of its methods to the inner one, except those necessary to encode variants. For those, it will encode the variant, then forward to the corresponding non-variant method so that chaining `StructMapSerializer` with `VariantStringSerializer` works together correctly.

For wrapping `StructMapSerializer` with `VariantStringSerializer`, I had to introduce a new trait. Since both serializers modify the `Serializer::serialize_struct_variant` method, they could not really forward to eachother properly using just the `Serializer` trait. `SerializeParts` is a new trait for doing sub-part serialization, and in particular it has a method for serializing just the ident of an enum variant.

For deserializing this, I removed the code in `VariantAccess` which limited variants to be only integers. Since serde naturally allows for using strings to identify enums, nothing more was necessary.

Fixes #172.

Supersedes and closes #154.

<details>
  <summary>Original PR description</summary>
Edit: This is an alternative to #180. #180 is significantly nicer, but is not backwards compatible.

---


While this works, there are some drawbacks that I'm not sure about:

- I had to remove some code in the `VariantAccess` decoding structure. It was hardcoded to only accept `u32` for enum variants. Instead, it now forwards the deserialization directly to the underlying implementation so that the enum variant can be deserialized either with a u32 or a string.
- Using `with_struct_map` or `with_struct_tuple` _after_ `with_string_variants` will clobber its behavior. `VariantStringSerializer` correctly respects underlying struct encoding, but `StructMapSerializer` and `StructTupleSerializer` are both still hardcoded to use integer indices in places.

One last note: the test `round_trip_untagged_enum_with_enum_associated_data` is currently failing, but that should be fixed by https://github.com/serde-rs/serde/pull/1438.

</details>