### PR TITLE
fix: error reading enum with struct-like variants 

### DIFF
--- a/rmp-serde/src/ext.rs
+++ b/rmp-serde/src/ext.rs
@@ -213,7 +213,8 @@ where
 
     #[inline]
     fn serialize_struct_variant(self, _name: &'static str, variant_index: u32, _variant: &'static str, len: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
-        encode::write_array_len(self.se.get_mut(), 2)?;
+        // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
+        encode::write_map_len(&mut self.se.get_mut(), 1)?;
         self.se.serialize_u32(variant_index)?;
         encode::write_map_len(self.se.get_mut(), len as u32)?;
         Ok(self)
@@ -463,7 +464,8 @@ where
 
     #[inline]
     fn serialize_struct_variant(self, _name: &'static str, variant_index: u32, _variant: &'static str, len: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
-        encode::write_array_len(&mut self.se.get_mut(), 2)?;
+        // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
+        encode::write_map_len(&mut self.se.get_mut(), 1)?;
         self.se.serialize_u32(variant_index)?;
         encode::write_array_len(self.se.get_mut(), len as u32)?;
         Ok(self)

--- a/rmp-serde/tests/encode_derive.rs
+++ b/rmp-serde/tests/encode_derive.rs
@@ -164,8 +164,8 @@ fn serialize_struct_variant_as_map() {
         .with_struct_map();
     Enum::V1 { f1: 42 }.serialize(&mut se).unwrap();
 
-    // Expect: [0, {"f1": 42}].
-    assert_eq!(vec![0x92, 0x00, 0x81, 0xa2, 0x66, 0x31, 0x2a], se.into_inner());
+    // Expect: {0 => {"f1": 42}}.
+    assert_eq!(vec![0x81, 0x00, 0x81, 0xa2, 0x66, 0x31, 0x2a], se.into_inner());
 }
 
 #[test]

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::io::Cursor;
 
 use serde::{Deserialize, Serialize};
+use rmps::encode::Ext;
 use rmps::{Deserializer, Serializer};
 
 #[test]
@@ -76,6 +77,64 @@ fn round_trip_option_cow() {
     expected.serialize(&mut Serializer::new(&mut buf)).unwrap();
 
     let mut de = Deserializer::new(Cursor::new(&buf[..]));
+
+    assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
+}
+
+#[test]
+fn round_struct_like_enum() {
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum Enum {
+        A { data: u32 },
+    }
+
+    let expected = Enum::A { data: 42 };
+    let mut buf = Vec::new();
+    expected.serialize(&mut Serializer::new(&mut buf)).unwrap();
+
+    let mut de = Deserializer::new(&buf[..]);
+
+    assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
+}
+
+#[test]
+fn round_struct_like_enum_with_struct_map() {
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum Enum {
+        A { data: u32 },
+    }
+
+    let expected = Enum::A { data: 42 };
+    let mut buf = Vec::new();
+    expected
+        .serialize(&mut Serializer::new(&mut buf).with_struct_map())
+        .unwrap();
+
+    let mut de = Deserializer::new(&buf[..]);
+
+    assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
+}
+
+#[test]
+fn round_struct_like_enum_with_struct_tuple() {
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum Enum {
+        A { data: u32 },
+    }
+
+    let expected = Enum::A { data: 42 };
+    let mut buf = Vec::new();
+    expected
+        .serialize(&mut Serializer::new(&mut buf).with_struct_tuple())
+        .unwrap();
+
+    let mut de = Deserializer::new(&buf[..]);
 
     assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
 }


### PR DESCRIPTION
Fixes #201.

This changes the ext encoders to be consistent with `Serializer` when encoding enum struct variants. Now both encode enum variants as a map `{idx => data}`, rather than an array `[idx, data]`.

Includes two round-trip tests using each ext encoder, and one using Serializer to ensure this continues to function.