### PR TITLE
Bump test's required rustc version to 1.31.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 rust:
   - nightly
   - stable
-  - 1.30.1
+  - 1.31.1
 
 before_script:
   - |


### PR DESCRIPTION
This fixes compilation for proc-macro2 1.0.0 which serde_derive updated to.

We could also just remove this requirement and just run tests on the latest stable? I'm not sure which would be better. We would still be running `cargo build` on `1.16.0` in any case.