### PR TITLE
Add configuration option for writing enum variants as strings

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -565,11 +565,7 @@ impl<'de, 'a, R: ReadSlice<'de>> de::EnumAccess<'de> for VariantAccess<'a, R> {
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Error>
         where V: de::DeserializeSeed<'de>,
     {
-        use serde::de::IntoDeserializer;
-
-        let idx: u32 = serde::Deserialize::deserialize(&mut *self.de)?;
-        let val: Result<_, Error> = seed.deserialize(idx.into_deserializer());
-        Ok((val?, self))
+        Ok((seed.deserialize(&mut *self.de)?, self))
     }
 }
 


### PR DESCRIPTION
Submitting this after #207 was merged.

Adds a config option for encoding enums variant names as strings. Does not change any defaults.

Notably, this does not change `rmp_serde::to_vec_named`. That remains encoding struct fields names as strings, but enum variants as integers.

Fixes #172. Supersedes and closes #154.