### PR TITLE
Allow timestamp extension

### DIFF
--- a/rmp/src/encode/mod.rs
+++ b/rmp/src/encode/mod.rs
@@ -257,8 +257,6 @@ pub fn write_map_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWrit
 /// Panics if `ty` is negative, because it is reserved for future MessagePack extension including
 /// 2-byte type information.
 pub fn write_ext_meta<W: Write>(wr: &mut W, len: u32, ty: i8) -> Result<Marker, ValueWriteError> {
-    assert!(ty >= 0);
-
     let marker = match len {
         1 => {
             write_marker(wr, Marker::FixExt1)?;

--- a/rmp/tests/func/encode/ext.rs
+++ b/rmp/tests/func/encode/ext.rs
@@ -29,6 +29,13 @@ fn pass_pack_meta_fix4() {
 }
 
 #[test]
+fn pass_pack_meta_fix4_timesamp() {
+    let mut buf = [0x00, 0x00];
+    assert_eq!(Marker::FixExt4, write_ext_meta(&mut &mut buf[..], 4, -1).unwrap());
+    assert_eq!([0xd6, 0xff], buf);
+}
+
+#[test]
 fn pass_pack_meta_fix8() {
     let mut buf = [0x00, 0x00];
 


### PR DESCRIPTION
The timestamp extension is using `-1` as identifier, support such negative values.

Closes #174.