### PR TITLE
square bracket indexing of maps (e.g. val["key"])

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -847,6 +847,27 @@ impl Index<usize> for Value {
     }
 }
 
+impl Index<&str> for Value {
+    type Output = Value;
+    fn index(&self, index: &str) -> &Value {
+        if let Value::Map(ref map) = *self {
+            if let Some(found) = map.iter().find(
+                |(key, _val)|  {
+                if let Value::String(ref strval) = *key {
+                    if let Some(s) = strval.as_str() {
+                        if s == index { return true; }
+                    }
+                }
+                return false;
+                })
+            {
+                return &found.1;
+            }
+        }
+        &NIL
+    }
+}
+
 impl From<bool> for Value {
     fn from(v: bool) -> Self {
         Value::Boolean(v)

--- a/rmpv/tests/value.rs
+++ b/rmpv/tests/value.rs
@@ -146,3 +146,24 @@ fn monadic_index() {
     assert!(val[2].is_nil());
     assert!(val[1][2][3][4][5].is_nil());
 }
+
+#[test]
+fn index_into_map() {
+    let val = Value::Map(vec![
+        ( Value::String("a".into()), Value::from(1) ),
+        ( Value::String("b".into()), Value::Array(vec![
+            Value::from(3),
+            Value::from(4),
+            Value::from(5)
+        ])),
+        ( Value::String("c".into()), Value::Map(vec![
+            ( Value::String("d".into()), Value::from(8) ),
+            ( Value::String("e".into()), Value::from(9) )
+        ]))
+    ]);        
+    assert_eq!(1, val["a"].as_i64().unwrap());
+    assert_eq!(5, val["b"][2].as_i64().unwrap());
+    assert_eq!(9, val["c"]["e"].as_i64().unwrap());
+    assert!(val["b"][3].is_nil());
+    assert!(val["d"][4].is_nil());
+}


### PR DESCRIPTION
Consider the use case of json data.

Here is an implementation of val["key"] indexing of maps, and some tests which show results similar to the existing tests for indexing arrays.

This is incomplete (it doesn't support String as an index, among others).
It's verbose for the sake of discussion, and would be more consistent with existing code if it used iterators.

As it stands, this is just an example as a suggestion.