### PR TITLE
Implement TryFrom for Value and ValueRef

### DIFF
--- a/rmpv/tests/value.rs
+++ b/rmpv/tests/value.rs
@@ -185,3 +185,13 @@ fn index_into_map() {
     assert!(val["b"][3].is_nil());
     assert!(val["d"][4].is_nil());
 }
+
+#[test]
+fn try_from_val() {
+  use rmpv::Utf8String;
+  use std::convert::TryInto;
+
+  assert_eq!(false, Value::Boolean(false).try_into().unwrap());
+  assert_eq!(Utf8String::from("spook"), Value::from("spook").try_into().unwrap());
+  assert_eq!(vec![0], TryInto::<Vec<u8>>::try_into(Value::Binary(vec![0u8])).unwrap());
+}


### PR DESCRIPTION
Closes https://github.com/3Hren/msgpack-rust/issues/227.

Some comments:

* I didn't do formatting, since there's no `rustfmt.toml`. When the code is ready to be accepted I'll add a commit where I'll manually try to style things similar to the rest of the code

* When implementing nontrivial `TryFrom` things, I just looked at what `as_*` methods are available and mimicked that. I don't fully understand the thought behind it (e.g. I could surely imagine `ValueRef::as_i64` existing, or `Value::as_f32`), but since this is more of a "convenience implementation", I figured I'd stay with consistency.

* I didn't go overboard with tests, since everything's either trivial or refers to already existing implementations (such as `as_f64`). Let me know if more is desirable. Also, there is no `tests/value_ref.rs`, so I left that out, too.