### PR TITLE
Implement TryInto<String> for Value

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -1056,6 +1056,19 @@ impl TryFrom<Value> for f64 {
       }
   }
 }
+
+impl TryFrom<Value> for String {
+  type Error = Value;
+
+  fn try_from(val: Value) -> Result<Self, Self::Error> {
+    match val {
+      Value::String(Utf8String{ s: Ok(u)}) => {
+        Ok(u)
+      }
+      _ => Err(val)
+    }
+  }
+}
 // The following impl was left out intentionally, see
 // https://github.com/3Hren/msgpack-rust/pull/228#discussion_r359513925
 /*

--- a/rmpv/tests/value.rs
+++ b/rmpv/tests/value.rs
@@ -193,5 +193,6 @@ fn try_from_val() {
 
   assert_eq!(false, Value::Boolean(false).try_into().unwrap());
   assert_eq!(Utf8String::from("spook"), Value::from("spook").try_into().unwrap());
+  assert_eq!(String::from("spook"), TryInto::<String>::try_into(Value::from("spook")).unwrap());
   assert_eq!(vec![0], TryInto::<Vec<u8>>::try_into(Value::Binary(vec![0u8])).unwrap());
 }


### PR DESCRIPTION
I missed that with the last PR, but it's actually the most important part imho :)

It might also be implemented for `Utf8String`, but it would make most sense with `type Error = (Vec<u8>, Uf8Error)`, and I wasn't sure if you wanted to expose the internal details of this type.

Let me know what you think :)