### PR TITLE
Set 'is_human_readable()' to false

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -638,6 +638,10 @@ impl<'de, 'a, R: ReadSlice<'de>> serde::Deserializer<'de> for &'a mut Deserializ
         }
     }
 
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 char
         str string bytes byte_buf unit seq map

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -569,6 +569,10 @@ where
         C::write_variant_ident(self, id, variant)?;
         self.serialize_struct(name, len)
     }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 impl<'a, W: Write + 'a> serde::Serializer for &mut ExtFieldSerializer<'a, W> {


### PR DESCRIPTION
This makes using [serde-diff](https://docs.rs/serde-diff) possible, which has [special code-paths](https://github.com/amethyst/serde-diff/blob/master/src/lib.rs#L307:L307)
to pre-count elements that otherwise would be generated lazily.

Currently, using serge-diff with Msgpack is not possible directly, as msgpack-rust incorrectly reports that it is human readable. The latter is the default implementation of the [`serde::Serializer`](https://docs.rs/serde/1.0.104/serde/trait.Serializer.html#method.is_human_readable) and [`serde::Deserializer`](https://docs.rs/serde/1.0.104/serde/trait.Deserializer.html#method.is_human_readable) traits.

Apologies for not writing tests to pin this setting, but didn't manage to get a Deserializer instance that implements `serde::de::Deserializer`.