### PR TITLE
Update to features of Rust 1.34.2, the latest tested one according to Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ deserializing Rust structs.
 
 ## Requirements
 
-- Rust 1.16
+- Rust 1.34.2
 
 ## Versioning
 

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -271,6 +271,7 @@ pub struct Compound<'a, W: 'a, C: 'a> {
 }
 
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub struct ExtFieldSerializer<'a, W> {
     wr: &'a mut W,
     tag: Option<i8>,

--- a/rmp/src/decode/mod.rs
+++ b/rmp/src/decode/mod.rs
@@ -18,6 +18,7 @@ mod uint;
 pub use self::sint::{read_nfix, read_i8, read_i16, read_i32, read_i64};
 pub use self::uint::{read_pfix, read_u8, read_u16, read_u32, read_u64};
 pub use self::dec::{read_f32, read_f64};
+#[allow(deprecated)] // While we re-export deprecated items, we don't want to trigger warnings while compiling this crate
 pub use self::str::{read_str_len, read_str, read_str_from_slice, read_str_ref, DecodeStringError};
 pub use self::ext::{read_fixext1, read_fixext2, read_fixext4, read_fixext8, read_fixext16, read_ext_meta, ExtMeta};
 

--- a/rmp/src/marker.rs
+++ b/rmp/src/marker.rs
@@ -86,7 +86,6 @@ impl Marker {
             0xdd => Marker::Array32,
             0xde => Marker::Map16,
             0xdf => Marker::Map32,
-            _ => unreachable!(),
         }
     }
 


### PR DESCRIPTION
Admittedly this PR is a bit of a guess, as ran the changes against rustc 1.40, and in the hopes that Travis will be OK with it.

This PR is also based on the assumption that the README is outdated.