### PR TITLE
Have a way to "destructure" a Utf8StringRef.

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -347,8 +347,13 @@ impl<'a> Utf8StringRef<'a> {
     }
 
     /// Consumes this object, yielding the string if the string is valid UTF-8, or else `None`.
-    pub fn into_str(self) -> Option<String> {
+    pub fn into_string(self) -> Option<String> {
         self.s.ok().map(|s| s.into())
+    }
+
+    /// Consumes this object, yielding the string reference if the string is valid UTF-8, or else `None`.
+    pub fn into_str(self) -> Option<&'a str> {
+        self.s.ok()
     }
 
     /// Converts a `Utf8StringRef` into a byte vector.


### PR DESCRIPTION
I need to consume the Utf8StringRef while returning the internal
reference for lifetime reasons. Using as_str makes it look like it is
borrowing from the Utf8StringRef instead of the source.

Sorry for the API breakage on into_str, if you want I can rename the
new method into_borrowed_str or something.