### PR TITLE
Update for serde 1.0.116 and add tests

### DIFF
--- a/rmp-serde/Cargo.toml
+++ b/rmp-serde/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.2"
-serde = "1.0.99"
+serde = "1.0.116"
 rmp = { version = "0.8.8", path = "../rmp" }
 
 [dev-dependencies]
 rmpv = { path = "../rmpv" }
 serde_bytes = "0.11.2"
-serde_derive = "1.0.99"
+serde_derive = "1.0.116"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -381,11 +381,50 @@ fn round_variant_string() {
     do_test!(|b| Serializer::new(b).with_integer_variants().with_string_variants());
 }
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[test]
-fn roundtrip_ip_addr() {
+fn roundtrip_ipv4addr() {
+    assert_roundtrips(Ipv4Addr::new(127, 0, 0, 1));
+}
+
+#[test]
+fn roundtrip_ipv6addr() {
+    assert_roundtrips(Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8));
+}
+
+#[test]
+fn roundtrip_ipaddr_ipv4addr() {
     assert_roundtrips(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+}
+
+#[test]
+fn roundtrip_ipaddr_ipv6addr() {
+    assert_roundtrips(IpAddr::V6(Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8)));
+}
+
+#[test]
+fn roundtrip_result_ipv4addr() {
+    let val: Result<Ipv4Addr, ()> = Ok(Ipv4Addr::new(127, 0, 0, 1));
+    assert_roundtrips(val);
+}
+
+#[test]
+fn roundtrip_result_num() {
+    assert_roundtrips(Ok::<u32, u32>(42));
+    assert_roundtrips(Err::<(),_>(222));
+}
+
+#[test]
+fn roundtrip_simple_enum() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    enum SimpleEnum {
+        V1(u32),
+        V2(String),
+    }
+
+    assert_roundtrips(SimpleEnum::V1(42));
+    assert_roundtrips(SimpleEnum::V2("hello".into()));
 }
 
 #[test]
@@ -403,7 +442,6 @@ fn roundtrip_some() {
 #[test]
 fn roundtrip_some_failures() {
     // FIXME
-    assert_roundtrips(Err::<(),_>(222));
     assert_roundtrips(Some(None::<()>));
 }
 

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::io::Cursor;
 use serde::{Deserialize, Serialize};
 use rmps::{Deserializer, Serializer};
+use rmps::config::{DefaultConfig, SerializerConfig};
 
 #[test]
 fn round_trip_option() {
@@ -447,12 +448,46 @@ fn roundtrip_some_failures() {
 
 #[cfg(test)]
 fn assert_roundtrips<T: PartialEq + std::fmt::Debug + Serialize + for<'a> Deserialize<'a>>(val: T) {
-    let serialized = rmp_serde::to_vec(&val).unwrap();
-    let val2: T = match rmp_serde::from_slice(&serialized) {
+    assert_roundtrips_config(&val, "default", |s| s);
+    assert_roundtrips_config(&val, ".with_struct_map()", |s| s.with_struct_map());
+    assert_roundtrips_config(&val, ".with_string_variants()", |s| {
+        s.with_string_variants()
+    });
+    assert_roundtrips_config(&val, ".with_struct_map().with_string_variants()", |s| {
+        s.with_struct_map().with_string_variants()
+    });
+}
+
+#[cfg(test)]
+fn assert_roundtrips_config<T, CSF, C>(val: &T, desc: &str, config_serializer: CSF)
+where
+    T: PartialEq + std::fmt::Debug + Serialize + for<'a> Deserialize<'a>,
+    CSF: FnOnce(Serializer<Vec<u8>, DefaultConfig>) -> Serializer<Vec<u8>, C>,
+    C: SerializerConfig,
+{
+    let mut serializer = config_serializer(Serializer::new(Vec::new()));
+    if let Err(e) = val.serialize(&mut serializer) {
+        panic!(
+            "Failed to serialize: {}\nConfig: {}\nValue: {:?}\n",
+            e, desc, val
+        );
+    }
+    let serialized = serializer.into_inner();
+
+    let mut deserializer = Deserializer::new(serialized.as_slice());
+    let val2: T = match T::deserialize(&mut deserializer) {
         Ok(t) => t,
         Err(e) => {
-            panic!("Does not deserialize: {}\nSerialized {:?}\nGot {:?}\n", e, val, rmpv::decode::value::read_value(&mut serialized.as_slice()).expect("rmp didn't serialize correctly at all"));
-        },
+            panic!(
+                "Does not deserialize: {}\nConfig: {}\nSerialized {:?}\nGot {:?}\n",
+                e,
+                desc,
+                val,
+                rmpv::decode::value::read_value(&mut serialized.as_slice())
+                    .expect("rmp didn't serialize correctly at all")
+            );
+        }
     };
-    assert_eq!(val2, val);
+
+    assert_eq!(val, &val2, "Config: {}", desc);
 }

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -447,11 +447,11 @@ fn roundtrip_some_failures() {
 
 #[cfg(test)]
 fn assert_roundtrips<T: PartialEq + std::fmt::Debug + Serialize + for<'a> Deserialize<'a>>(val: T) {
-    let seriaized = rmp_serde::to_vec(&val).unwrap();
-    let val2: T = match rmp_serde::from_slice(&seriaized) {
+    let serialized = rmp_serde::to_vec(&val).unwrap();
+    let val2: T = match rmp_serde::from_slice(&serialized) {
         Ok(t) => t,
         Err(e) => {
-            panic!("Does not deserialize: {}\nSerialized {:?}\nGot {:?}\n", e, val, rmpv::decode::value::read_value(&mut seriaized.as_slice()).expect("rmp didn't serialize corerctly at all"));
+            panic!("Does not deserialize: {}\nSerialized {:?}\nGot {:?}\n", e, val, rmpv::decode::value::read_value(&mut serialized.as_slice()).expect("rmp didn't serialize correctly at all"));
         },
     };
     assert_eq!(val2, val);

--- a/rmpv/Cargo.toml
+++ b/rmpv/Cargo.toml
@@ -18,7 +18,7 @@ with-serde = ["serde", "serde_bytes"]
 serde_bytes = { version = "0.11.2", optional = true }
 rmp = { version = "0.8.8", path = "../rmp" }
 num-traits = "0.2.8"
-serde = { version = "1.0.99", optional = true }
+serde = { version = "1.0.116", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9"


### PR DESCRIPTION
This updates to serde 1.0.116 to get the fix for
https://github.com/serde-rs/serde/pull/1888 , and then adds more tests,
including tests for roundtrips for every serializer configuration.