### PR TITLE
Add config to choose binary vs human-readable, for Serializer and Deserializer

### DIFF
--- a/rmp-serde/Cargo.toml
+++ b/rmp-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmp-serde"
-version = "0.14.4"
+version = "0.15.0"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 license = "MIT"
 description = "Serde bindings for RMP"

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -195,7 +195,7 @@ impl<'a, W: Write + 'a, C> Serializer<W, C> {
 impl<W: Write, C> Serializer<W, C> {
     /// Consumes this serializer returning the new one, which will serialize structs as a map.
     ///
-    /// This is used, when you the default struct serialization as a tuple does not fit your
+    /// This is used, when the default struct serialization as a tuple does not fit your
     /// requirements.
     pub fn with_struct_map(self) -> Serializer<W, StructMapConfig<C>> {
         let Serializer { wr, depth, config } = self;
@@ -222,7 +222,7 @@ impl<W: Write, C> Serializer<W, C> {
 
     /// Consumes this serializer returning the new one, which will serialize enum variants as strings.
     ///
-    /// This is used, when you the default struct serialization as integers does not fit your
+    /// This is used, when the default struct serialization as integers does not fit your
     /// requirements.
     pub fn with_string_variants(self) -> Serializer<W, VariantStringConfig<C>> {
         let Serializer { wr, depth, config } = self;

--- a/rmpv-tests/Cargo.toml
+++ b/rmpv-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-rmp-serde = { version = "0.14", path = "../rmp-serde" }
+rmp-serde = { version = "0.15", path = "../rmp-serde" }
 rmpv = { features = ["with-serde"], path = "../rmpv" }
 
 [dev-dependencies]


### PR DESCRIPTION
Add a defaulted type parameter to `Deserializer` and all its auxiliary
types, threading the config ZSTs through. Delegate
`Serializer::is_human_readable` and `Deserializer::is_human_readable` to
the config. Test round-tripping for the new config variants this
introduces.