### PR TITLE
Add serde 128-bit integer support

### DIFF
--- a/rmp-serde/CHANGELOG.md
+++ b/rmp-serde/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `UnderlyingWrite` trait for `Serializer` and its wrappers to be able to obtain the underlying writer.
 - Add missing `Debug` implementations.
 - More `decode::Error` conversions.
+- Support for serializing and deserializing 128-bit values in serde.
 
 ### Changed:
 - (Breaking) Serialize newtype structs by serializing its inner type without wrapping into a tuple.

--- a/rmp-serde/Cargo.toml
+++ b/rmp-serde/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["msgpack", "MessagePack", "serde", "serialization"]
 categories = ["encoding"]
 edition = "2018"
 
+[features]
+serde128 = []
+
 [dependencies]
 byteorder = "1.3.2"
 serde = "1.0.116"

--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -11,11 +11,11 @@ use serde;
 use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, Visitor};
 
 use rmp;
+use rmp::decode::{self, DecodeStringError, MarkerReadError, NumValueReadError, ValueReadError};
 use rmp::Marker;
-use rmp::decode::{self, MarkerReadError, DecodeStringError, ValueReadError, NumValueReadError};
 
+use crate::config::{BinaryConfig, DefaultConfig, HumanReadableConfig, SerializerConfig};
 use crate::MSGPACK_EXT_STRUCT_NAME;
-use crate::config::{DefaultConfig, SerializerConfig, HumanReadableConfig, BinaryConfig};
 
 /// Enum representing errors that can occur while decoding MessagePack data.
 #[derive(Debug)]
@@ -73,7 +73,9 @@ impl de::Error for Error {
 impl Display for Error {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
-            Error::InvalidMarkerRead(ref err) => write!(fmt, "IO error while reading marker: {}", err),
+            Error::InvalidMarkerRead(ref err) => {
+                write!(fmt, "IO error while reading marker: {}", err)
+            }
             Error::InvalidDataRead(ref err) => write!(fmt, "IO error while reading data: {}", err),
             Error::TypeMismatch(ref actual_marker) => {
                 write!(fmt, "wrong msgpack marker {:?}", actual_marker)
@@ -133,7 +135,9 @@ impl<'a> From<DecodeStringError<'a>> for Error {
             DecodeStringError::InvalidMarkerRead(err) => Error::InvalidMarkerRead(err),
             DecodeStringError::InvalidDataRead(err) => Error::InvalidDataRead(err),
             DecodeStringError::TypeMismatch(marker) => Error::TypeMismatch(marker),
-            DecodeStringError::BufferSizeTooSmall(..) => Error::Uncategorized("BufferSizeTooSmall".to_string()),
+            DecodeStringError::BufferSizeTooSmall(..) => {
+                Error::Uncategorized("BufferSizeTooSmall".to_string())
+            }
             DecodeStringError::InvalidUtf8(..) => Error::Uncategorized("InvalidUtf8".to_string()),
         }
     }
@@ -155,7 +159,7 @@ pub struct Deserializer<R, C = DefaultConfig> {
 
 impl<R: Read> Deserializer<ReadReader<R>, DefaultConfig> {
     #[doc(hidden)]
-    #[deprecated(note="use `Deserializer::new` instead")]
+    #[deprecated(note = "use `Deserializer::new` instead")]
     pub fn from_read(rd: R) -> Self {
         Self::new(rd)
     }
@@ -196,7 +200,12 @@ impl<R: Read, C: SerializerConfig> Deserializer<R, C> {
     /// This is primarily useful if you need to interoperate with serializations produced by older
     /// versions of `rmp-serde`.
     pub fn with_human_readable(self) -> Deserializer<R, HumanReadableConfig<C>> {
-        let Deserializer { rd, config, marker, depth } = self;
+        let Deserializer {
+            rd,
+            config,
+            marker,
+            depth,
+        } = self;
         Deserializer {
             rd,
             config: HumanReadableConfig::new(config),
@@ -211,7 +220,12 @@ impl<R: Read, C: SerializerConfig> Deserializer<R, C> {
     /// This is the default MessagePack deserialization mechanism, consuming the most compact
     /// representation.
     pub fn with_binary(self) -> Deserializer<R, BinaryConfig<C>> {
-        let Deserializer { rd, config, marker, depth } = self;
+        let Deserializer {
+            rd,
+            config,
+            marker,
+            depth,
+        } = self;
         Deserializer {
             rd,
             config: BinaryConfig::new(config),
@@ -229,8 +243,8 @@ impl<R: AsRef<[u8]>> Deserializer<ReadReader<Cursor<R>>> {
 }
 
 impl<'de, R> Deserializer<ReadRefReader<'de, R>>
-    where
-        R: AsRef<[u8]> + ?Sized
+where
+    R: AsRef<[u8]> + ?Sized,
 {
     /// Constructs a new `Deserializer` from the given byte slice.
     pub fn from_read_ref(rd: &'de R) -> Self {
@@ -255,7 +269,8 @@ impl<'de, R: ReadSlice<'de>, C: SerializerConfig> Deserializer<R, C> {
     }
 
     fn read_str_data<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         match self.read_bin_data(len as u32)? {
             Reference::Borrowed(buf) => {
@@ -285,36 +300,69 @@ impl<'de, R: ReadSlice<'de>, C: SerializerConfig> Deserializer<R, C> {
         }
     }
 
-    fn read_bin_data<'a>(&'a mut self, len: u32) -> Result<Reference<'de,'a, [u8]>, Error> {
-        self.rd.read_slice(len as usize).map_err(Error::InvalidDataRead)
+    fn read_bin_data<'a>(&'a mut self, len: u32) -> Result<Reference<'de, 'a, [u8]>, Error> {
+        self.rd
+            .read_slice(len as usize)
+            .map_err(Error::InvalidDataRead)
     }
 
     fn read_ext<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         let ext_de = ExtDeserializer::new(self, len);
         visitor.visit_newtype_struct(ext_de)
     }
 
     fn read_array<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_seq(SeqAccess::new(self, len as usize))
     }
 
     fn read_map<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_map(MapAccess::new(self, len as usize))
     }
 
     fn read_bytes<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         match self.read_bin_data(len)? {
             Reference::Borrowed(buf) => visitor.visit_borrowed_bytes(buf),
             Reference::Copied(buf) => visitor.visit_bytes(buf),
         }
+    }
+
+    #[cfg(feature = "serde128")]
+    fn read_128(&mut self) -> Result<[u8; 16], Error> {
+        use std::convert::TryInto;
+
+        let marker = match self.marker.take() {
+            Some(marker) => marker,
+            None => rmp::decode::read_marker(&mut self.rd)?,
+        };
+
+        if marker != Marker::Bin8 {
+            return Err(Error::TypeMismatch(marker));
+        }
+
+        let len = read_u8(&mut self.rd)?;
+
+        if len != 16 {
+            return Err(Error::LengthMismatch(16));
+        }
+
+        let buf = match self.read_bin_data(len as u32)? {
+            Reference::Borrowed(buf) => buf,
+            Reference::Copied(buf) => buf,
+        };
+
+        Ok(buf.try_into().unwrap())
     }
 }
 
@@ -323,18 +371,20 @@ fn read_u8<R: Read>(rd: &mut R) -> Result<u8, Error> {
 }
 
 fn read_u16<R: Read>(rd: &mut R) -> Result<u16, Error> {
-    rd.read_u16::<byteorder::BigEndian>().map_err(Error::InvalidDataRead)
+    rd.read_u16::<byteorder::BigEndian>()
+        .map_err(Error::InvalidDataRead)
 }
 
 fn read_u32<R: Read>(rd: &mut R) -> Result<u32, Error> {
-    rd.read_u32::<byteorder::BigEndian>().map_err(Error::InvalidDataRead)
+    rd.read_u32::<byteorder::BigEndian>()
+        .map_err(Error::InvalidDataRead)
 }
 
 #[derive(Debug)]
 enum ExtDeserializerState {
     New,
     ReadTag,
-    ReadBinary
+    ReadBinary,
 }
 
 #[derive(Debug)]
@@ -342,7 +392,7 @@ struct ExtDeserializer<'a, R, C> {
     rd: &'a mut R,
     config: C,
     len: u32,
-    state: ExtDeserializerState
+    state: ExtDeserializerState,
 }
 
 impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> ExtDeserializer<'a, R, C> {
@@ -356,12 +406,15 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> ExtDeserializer<'a, R
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de> for ExtDeserializer<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
+    for ExtDeserializer<'a, R, C>
+{
     type Error = Error;
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         visitor.visit_seq(self)
     }
@@ -373,7 +426,9 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de> for ExtDeserializer<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de>
+    for ExtDeserializer<'a, R, C>
+{
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
@@ -381,20 +436,24 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de> fo
         T: DeserializeSeed<'de>,
     {
         match self.state {
-            ExtDeserializerState::New | ExtDeserializerState::ReadTag => Ok(Some(seed.deserialize(self)?)),
-            ExtDeserializerState::ReadBinary => Ok(None)
+            ExtDeserializerState::New | ExtDeserializerState::ReadTag => {
+                Ok(Some(seed.deserialize(self)?))
+            }
+            ExtDeserializerState::ReadBinary => Ok(None),
         }
     }
 }
 
-
 /// Deserializer for Ext SeqAccess
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de> for &mut ExtDeserializer<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
+    for &mut ExtDeserializer<'a, R, C>
+{
     type Error = Error;
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         match self.state {
             ExtDeserializerState::New => {
@@ -403,18 +462,17 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
                 visitor.visit_i8(tag)
             }
             ExtDeserializerState::ReadTag => {
-                let data = self.rd.read_slice(self.len as usize).map_err(Error::InvalidDataRead)?;
+                let data = self
+                    .rd
+                    .read_slice(self.len as usize)
+                    .map_err(Error::InvalidDataRead)?;
                 self.state = ExtDeserializerState::ReadBinary;
                 match data {
-                    Reference::Borrowed(bytes) => {
-                        visitor.visit_borrowed_bytes(bytes)
-                    }
-                    Reference::Copied(bytes) => {
-                        visitor.visit_bytes(bytes)
-                    }
+                    Reference::Borrowed(bytes) => visitor.visit_borrowed_bytes(bytes),
+                    Reference::Copied(bytes) => visitor.visit_bytes(bytes),
                 }
             }
-            ExtDeserializerState::ReadBinary => unreachable!()
+            ExtDeserializerState::ReadBinary => unreachable!(),
         }
     }
 
@@ -425,7 +483,9 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> for &'a mut Deserializer<R, C> {
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
+    for &'a mut Deserializer<R, C>
+{
     type Error = Error;
 
     fn is_human_readable(&self) -> bool {
@@ -433,7 +493,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         let marker = match self.marker.take() {
             Some(marker) => marker,
@@ -456,9 +517,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
             Marker::I64 => visitor.visit_i64(rmp::decode::read_data_i64(&mut self.rd)?),
             Marker::F32 => visitor.visit_f32(rmp::decode::read_data_f32(&mut self.rd)?),
             Marker::F64 => visitor.visit_f64(rmp::decode::read_data_f64(&mut self.rd)?),
-            Marker::FixStr(len) => {
-                self.read_str_data(len as u32, visitor)
-            }
+            Marker::FixStr(len) => self.read_str_data(len as u32, visitor),
             Marker::Str8 => {
                 let len = read_u8(&mut self.rd)?;
                 self.read_str_data(len as u32, visitor)
@@ -471,9 +530,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
                 let len = read_u32(&mut self.rd)?;
                 self.read_str_data(len as u32, visitor)
             }
-            Marker::FixArray(len) => {
-                self.read_array(len as u32, visitor)
-            }
+            Marker::FixArray(len) => self.read_array(len as u32, visitor),
             Marker::Array16 => {
                 let len = read_u16(&mut self.rd)?;
                 self.read_array(len as u32, visitor)
@@ -482,9 +539,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
                 let len = read_u32(&mut self.rd)?;
                 self.read_array(len, visitor)
             }
-            Marker::FixMap(len) => {
-                self.read_map(len as u32, visitor)
-            }
+            Marker::FixMap(len) => self.read_map(len as u32, visitor),
             Marker::Map16 => {
                 let len = read_u16(&mut self.rd)?;
                 self.read_map(len as u32, visitor)
@@ -542,7 +597,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         let marker = rmp::decode::read_marker(&mut self.rd)?;
 
@@ -554,8 +610,14 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
         }
     }
 
-    fn deserialize_enum<V>(self, _name: &str, _variants: &[&str], visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &[&str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
     {
         let marker = match self.marker.take() {
             Some(marker) => marker,
@@ -568,8 +630,13 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
         }
     }
 
-    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
     {
         if name == MSGPACK_EXT_STRUCT_NAME {
             let marker = match self.marker.take() {
@@ -577,33 +644,15 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
                 None => rmp::decode::read_marker(&mut self.rd)?,
             };
             let len = match marker {
-                Marker::FixExt1 => {
-                    1 as u32
-                }
-                Marker::FixExt2 => {
-                    2 as u32
-                }
-                Marker::FixExt4 => {
-                    4 as u32
-                }
-                Marker::FixExt8 => {
-                    8 as u32
-                }
-                Marker::FixExt16 => {
-                    16 as u32
-                }
-                Marker::Ext8 => {
-                    read_u8(&mut self.rd)? as u32
-                }
-                Marker::Ext16 => {
-                    read_u16(&mut self.rd)? as u32
-                }
-                Marker::Ext32 => {
-                    read_u32(&mut self.rd)? as u32
-                }
-                _ => {
-                    return Err(Error::TypeMismatch(marker))
-                }
+                Marker::FixExt1 => 1 as u32,
+                Marker::FixExt2 => 2 as u32,
+                Marker::FixExt4 => 4 as u32,
+                Marker::FixExt8 => 8 as u32,
+                Marker::FixExt16 => 16 as u32,
+                Marker::Ext8 => read_u8(&mut self.rd)? as u32,
+                Marker::Ext16 => read_u16(&mut self.rd)? as u32,
+                Marker::Ext32 => read_u32(&mut self.rd)? as u32,
+                _ => return Err(Error::TypeMismatch(marker)),
             };
 
             let ext_de = ExtDeserializer::new(self, len);
@@ -613,8 +662,13 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
         visitor.visit_newtype_struct(self)
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
     {
         // We need to special case this so that [] is treated as a unit struct when asked for,
         // but as a sequence otherwise. This is because we serialize unit structs as [] rather
@@ -632,8 +686,27 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
         }
     }
 
+    #[cfg(feature = "serde128")]
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let buf = self.read_128()?;
+        visitor.visit_i128(i128::from_be_bytes(buf))
+    }
+
+    #[cfg(feature = "serde128")]
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let buf = self.read_128()?;
+        visitor.visit_u128(u128::from_be_bytes(buf))
+    }
+
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         // This special case allows us to decode some integer types as floats when safe, and
         // asked for.
@@ -658,7 +731,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         // This special case allows us to decode some integer types as floats when safe, and
         // asked for. This is here to be consistent with 'f32'.
@@ -697,18 +771,18 @@ struct SeqAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> SeqAccess<'a, R, C> {
     fn new(de: &'a mut Deserializer<R, C>, len: usize) -> Self {
-        SeqAccess {
-            de,
-            left: len,
-        }
+        SeqAccess { de, left: len }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de> for SeqAccess<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de>
+    for SeqAccess<'a, R, C>
+{
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-        where T: DeserializeSeed<'de>
+    where
+        T: DeserializeSeed<'de>,
     {
         if self.left > 0 {
             self.left -= 1;
@@ -730,18 +804,18 @@ struct MapAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> MapAccess<'a, R, C> {
     fn new(de: &'a mut Deserializer<R, C>, len: usize) -> Self {
-        MapAccess {
-            de,
-            left: len,
-        }
+        MapAccess { de, left: len }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de> for MapAccess<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de>
+    for MapAccess<'a, R, C>
+{
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-        where K: DeserializeSeed<'de>
+    where
+        K: DeserializeSeed<'de>,
     {
         if self.left > 0 {
             self.left -= 1;
@@ -752,7 +826,8 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de> fo
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-        where V: DeserializeSeed<'de>
+    where
+        V: DeserializeSeed<'de>,
     {
         Ok(seed.deserialize(&mut *self.de)?)
     }
@@ -768,24 +843,27 @@ struct VariantAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> VariantAccess<'a, R, C> {
     pub fn new(de: &'a mut Deserializer<R, C>) -> Self {
-        VariantAccess {
-            de,
-        }
+        VariantAccess { de }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::EnumAccess<'de> for VariantAccess<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::EnumAccess<'de>
+    for VariantAccess<'a, R, C>
+{
     type Error = Error;
     type Variant = Self;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Error>
-        where V: de::DeserializeSeed<'de>,
+    where
+        V: de::DeserializeSeed<'de>,
     {
         Ok((seed.deserialize(&mut *self.de)?, self))
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de> for VariantAccess<'a, R, C> {
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de>
+    for VariantAccess<'a, R, C>
+{
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
@@ -794,19 +872,26 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de> for
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
-        where T: DeserializeSeed<'de>
+    where
+        T: DeserializeSeed<'de>,
     {
         seed.deserialize(self.de)
     }
 
     fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         de::Deserializer::deserialize_tuple(self.de, len, visitor)
     }
 
-    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
-        where V: Visitor<'de>
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
     {
         de::Deserializer::deserialize_tuple(self.de, fields.len(), visitor)
     }
@@ -878,7 +963,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ReadRefReader<'a, T> {
     fn new(rd: &'a T) -> Self {
         Self {
             rd,
-            buf: rd.as_ref()
+            buf: rd.as_ref(),
         }
     }
 }
@@ -913,9 +998,15 @@ fn test_as_ref_reader() {
     let mut rd = ReadRefReader::new(&buf);
 
     assert_eq!(rd.read_slice(1).unwrap(), Reference::Borrowed(&[0][..]));
-    assert_eq!(rd.read_slice(6).unwrap(), Reference::Borrowed(&[1, 2, 3, 4, 5, 6][..]));
+    assert_eq!(
+        rd.read_slice(6).unwrap(),
+        Reference::Borrowed(&[1, 2, 3, 4, 5, 6][..])
+    );
     assert!(rd.read_slice(5).is_err());
-    assert_eq!(rd.read_slice(4).unwrap(), Reference::Borrowed(&[7, 8, 9, 10][..]));
+    assert_eq!(
+        rd.read_slice(4).unwrap(),
+        Reference::Borrowed(&[7, 8, 9, 10][..])
+    );
 }
 
 /// Deserialize an instance of type `T` from an I/O stream of MessagePack.
@@ -926,8 +1017,9 @@ fn test_as_ref_reader() {
 /// by `T`. It can also fail if the structure is correct but `T`'s implementation of `Deserialize`
 /// decides that something is wrong with the data, for example required struct fields are missing.
 pub fn from_read<R, T>(rd: R) -> Result<T, Error>
-where R: Read,
-      T: DeserializeOwned
+where
+    R: Read,
+    T: DeserializeOwned,
 {
     Deserialize::deserialize(&mut Deserializer::new(rd))
 }
@@ -938,7 +1030,7 @@ where R: Read,
 #[doc(hidden)]
 pub fn from_slice<'a, T>(input: &'a [u8]) -> Result<T, Error>
 where
-    T: Deserialize<'a>
+    T: Deserialize<'a>,
 {
     from_read_ref(input)
 }

--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -11,11 +11,11 @@ use serde;
 use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, Visitor};
 
 use rmp;
-use rmp::decode::{self, DecodeStringError, MarkerReadError, NumValueReadError, ValueReadError};
 use rmp::Marker;
+use rmp::decode::{self, MarkerReadError, DecodeStringError, ValueReadError, NumValueReadError};
 
-use crate::config::{BinaryConfig, DefaultConfig, HumanReadableConfig, SerializerConfig};
 use crate::MSGPACK_EXT_STRUCT_NAME;
+use crate::config::{DefaultConfig, SerializerConfig, HumanReadableConfig, BinaryConfig};
 
 /// Enum representing errors that can occur while decoding MessagePack data.
 #[derive(Debug)]
@@ -73,9 +73,7 @@ impl de::Error for Error {
 impl Display for Error {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
-            Error::InvalidMarkerRead(ref err) => {
-                write!(fmt, "IO error while reading marker: {}", err)
-            }
+            Error::InvalidMarkerRead(ref err) => write!(fmt, "IO error while reading marker: {}", err),
             Error::InvalidDataRead(ref err) => write!(fmt, "IO error while reading data: {}", err),
             Error::TypeMismatch(ref actual_marker) => {
                 write!(fmt, "wrong msgpack marker {:?}", actual_marker)
@@ -135,9 +133,7 @@ impl<'a> From<DecodeStringError<'a>> for Error {
             DecodeStringError::InvalidMarkerRead(err) => Error::InvalidMarkerRead(err),
             DecodeStringError::InvalidDataRead(err) => Error::InvalidDataRead(err),
             DecodeStringError::TypeMismatch(marker) => Error::TypeMismatch(marker),
-            DecodeStringError::BufferSizeTooSmall(..) => {
-                Error::Uncategorized("BufferSizeTooSmall".to_string())
-            }
+            DecodeStringError::BufferSizeTooSmall(..) => Error::Uncategorized("BufferSizeTooSmall".to_string()),
             DecodeStringError::InvalidUtf8(..) => Error::Uncategorized("InvalidUtf8".to_string()),
         }
     }
@@ -159,7 +155,7 @@ pub struct Deserializer<R, C = DefaultConfig> {
 
 impl<R: Read> Deserializer<ReadReader<R>, DefaultConfig> {
     #[doc(hidden)]
-    #[deprecated(note = "use `Deserializer::new` instead")]
+    #[deprecated(note="use `Deserializer::new` instead")]
     pub fn from_read(rd: R) -> Self {
         Self::new(rd)
     }
@@ -200,12 +196,7 @@ impl<R: Read, C: SerializerConfig> Deserializer<R, C> {
     /// This is primarily useful if you need to interoperate with serializations produced by older
     /// versions of `rmp-serde`.
     pub fn with_human_readable(self) -> Deserializer<R, HumanReadableConfig<C>> {
-        let Deserializer {
-            rd,
-            config,
-            marker,
-            depth,
-        } = self;
+        let Deserializer { rd, config, marker, depth } = self;
         Deserializer {
             rd,
             config: HumanReadableConfig::new(config),
@@ -220,12 +211,7 @@ impl<R: Read, C: SerializerConfig> Deserializer<R, C> {
     /// This is the default MessagePack deserialization mechanism, consuming the most compact
     /// representation.
     pub fn with_binary(self) -> Deserializer<R, BinaryConfig<C>> {
-        let Deserializer {
-            rd,
-            config,
-            marker,
-            depth,
-        } = self;
+        let Deserializer { rd, config, marker, depth } = self;
         Deserializer {
             rd,
             config: BinaryConfig::new(config),
@@ -243,8 +229,8 @@ impl<R: AsRef<[u8]>> Deserializer<ReadReader<Cursor<R>>> {
 }
 
 impl<'de, R> Deserializer<ReadRefReader<'de, R>>
-where
-    R: AsRef<[u8]> + ?Sized,
+    where
+        R: AsRef<[u8]> + ?Sized
 {
     /// Constructs a new `Deserializer` from the given byte slice.
     pub fn from_read_ref(rd: &'de R) -> Self {
@@ -269,8 +255,7 @@ impl<'de, R: ReadSlice<'de>, C: SerializerConfig> Deserializer<R, C> {
     }
 
     fn read_str_data<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         match self.read_bin_data(len as u32)? {
             Reference::Borrowed(buf) => {
@@ -300,37 +285,31 @@ impl<'de, R: ReadSlice<'de>, C: SerializerConfig> Deserializer<R, C> {
         }
     }
 
-    fn read_bin_data<'a>(&'a mut self, len: u32) -> Result<Reference<'de, 'a, [u8]>, Error> {
-        self.rd
-            .read_slice(len as usize)
-            .map_err(Error::InvalidDataRead)
+    fn read_bin_data<'a>(&'a mut self, len: u32) -> Result<Reference<'de,'a, [u8]>, Error> {
+        self.rd.read_slice(len as usize).map_err(Error::InvalidDataRead)
     }
 
     fn read_ext<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         let ext_de = ExtDeserializer::new(self, len);
         visitor.visit_newtype_struct(ext_de)
     }
 
     fn read_array<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         visitor.visit_seq(SeqAccess::new(self, len as usize))
     }
 
     fn read_map<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         visitor.visit_map(MapAccess::new(self, len as usize))
     }
 
     fn read_bytes<V>(&mut self, len: u32, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         match self.read_bin_data(len)? {
             Reference::Borrowed(buf) => visitor.visit_borrowed_bytes(buf),
@@ -371,20 +350,18 @@ fn read_u8<R: Read>(rd: &mut R) -> Result<u8, Error> {
 }
 
 fn read_u16<R: Read>(rd: &mut R) -> Result<u16, Error> {
-    rd.read_u16::<byteorder::BigEndian>()
-        .map_err(Error::InvalidDataRead)
+    rd.read_u16::<byteorder::BigEndian>().map_err(Error::InvalidDataRead)
 }
 
 fn read_u32<R: Read>(rd: &mut R) -> Result<u32, Error> {
-    rd.read_u32::<byteorder::BigEndian>()
-        .map_err(Error::InvalidDataRead)
+    rd.read_u32::<byteorder::BigEndian>().map_err(Error::InvalidDataRead)
 }
 
 #[derive(Debug)]
 enum ExtDeserializerState {
     New,
     ReadTag,
-    ReadBinary,
+    ReadBinary
 }
 
 #[derive(Debug)]
@@ -392,7 +369,7 @@ struct ExtDeserializer<'a, R, C> {
     rd: &'a mut R,
     config: C,
     len: u32,
-    state: ExtDeserializerState,
+    state: ExtDeserializerState
 }
 
 impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> ExtDeserializer<'a, R, C> {
@@ -406,15 +383,12 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> ExtDeserializer<'a, R
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
-    for ExtDeserializer<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de> for ExtDeserializer<'a, R, C> {
     type Error = Error;
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         visitor.visit_seq(self)
     }
@@ -426,9 +400,7 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de>
-    for ExtDeserializer<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de> for ExtDeserializer<'a, R, C> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
@@ -436,24 +408,20 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de>
         T: DeserializeSeed<'de>,
     {
         match self.state {
-            ExtDeserializerState::New | ExtDeserializerState::ReadTag => {
-                Ok(Some(seed.deserialize(self)?))
-            }
-            ExtDeserializerState::ReadBinary => Ok(None),
+            ExtDeserializerState::New | ExtDeserializerState::ReadTag => Ok(Some(seed.deserialize(self)?)),
+            ExtDeserializerState::ReadBinary => Ok(None)
         }
     }
 }
 
+
 /// Deserializer for Ext SeqAccess
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
-    for &mut ExtDeserializer<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de> for &mut ExtDeserializer<'a, R, C> {
     type Error = Error;
 
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         match self.state {
             ExtDeserializerState::New => {
@@ -462,17 +430,18 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
                 visitor.visit_i8(tag)
             }
             ExtDeserializerState::ReadTag => {
-                let data = self
-                    .rd
-                    .read_slice(self.len as usize)
-                    .map_err(Error::InvalidDataRead)?;
+                let data = self.rd.read_slice(self.len as usize).map_err(Error::InvalidDataRead)?;
                 self.state = ExtDeserializerState::ReadBinary;
                 match data {
-                    Reference::Borrowed(bytes) => visitor.visit_borrowed_bytes(bytes),
-                    Reference::Copied(bytes) => visitor.visit_bytes(bytes),
+                    Reference::Borrowed(bytes) => {
+                        visitor.visit_borrowed_bytes(bytes)
+                    }
+                    Reference::Copied(bytes) => {
+                        visitor.visit_bytes(bytes)
+                    }
                 }
             }
-            ExtDeserializerState::ReadBinary => unreachable!(),
+            ExtDeserializerState::ReadBinary => unreachable!()
         }
     }
 
@@ -483,9 +452,7 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::Deserializer<'de>
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
-    for &'a mut Deserializer<R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> for &'a mut Deserializer<R, C> {
     type Error = Error;
 
     fn is_human_readable(&self) -> bool {
@@ -493,8 +460,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         let marker = match self.marker.take() {
             Some(marker) => marker,
@@ -517,7 +483,9 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
             Marker::I64 => visitor.visit_i64(rmp::decode::read_data_i64(&mut self.rd)?),
             Marker::F32 => visitor.visit_f32(rmp::decode::read_data_f32(&mut self.rd)?),
             Marker::F64 => visitor.visit_f64(rmp::decode::read_data_f64(&mut self.rd)?),
-            Marker::FixStr(len) => self.read_str_data(len as u32, visitor),
+            Marker::FixStr(len) => {
+                self.read_str_data(len as u32, visitor)
+            }
             Marker::Str8 => {
                 let len = read_u8(&mut self.rd)?;
                 self.read_str_data(len as u32, visitor)
@@ -530,7 +498,9 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
                 let len = read_u32(&mut self.rd)?;
                 self.read_str_data(len as u32, visitor)
             }
-            Marker::FixArray(len) => self.read_array(len as u32, visitor),
+            Marker::FixArray(len) => {
+                self.read_array(len as u32, visitor)
+            }
             Marker::Array16 => {
                 let len = read_u16(&mut self.rd)?;
                 self.read_array(len as u32, visitor)
@@ -539,7 +509,9 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
                 let len = read_u32(&mut self.rd)?;
                 self.read_array(len, visitor)
             }
-            Marker::FixMap(len) => self.read_map(len as u32, visitor),
+            Marker::FixMap(len) => {
+                self.read_map(len as u32, visitor)
+            }
             Marker::Map16 => {
                 let len = read_u16(&mut self.rd)?;
                 self.read_map(len as u32, visitor)
@@ -597,8 +569,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         let marker = rmp::decode::read_marker(&mut self.rd)?;
 
@@ -610,14 +581,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
         }
     }
 
-    fn deserialize_enum<V>(
-        self,
-        _name: &str,
-        _variants: &[&str],
-        visitor: V,
-    ) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+    fn deserialize_enum<V>(self, _name: &str, _variants: &[&str], visitor: V) -> Result<V::Value, Error>
+        where V: Visitor<'de>
     {
         let marker = match self.marker.take() {
             Some(marker) => marker,
@@ -630,13 +595,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
         }
     }
 
-    fn deserialize_newtype_struct<V>(
-        self,
-        name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Error>
+        where V: Visitor<'de>
     {
         if name == MSGPACK_EXT_STRUCT_NAME {
             let marker = match self.marker.take() {
@@ -644,15 +604,33 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
                 None => rmp::decode::read_marker(&mut self.rd)?,
             };
             let len = match marker {
-                Marker::FixExt1 => 1 as u32,
-                Marker::FixExt2 => 2 as u32,
-                Marker::FixExt4 => 4 as u32,
-                Marker::FixExt8 => 8 as u32,
-                Marker::FixExt16 => 16 as u32,
-                Marker::Ext8 => read_u8(&mut self.rd)? as u32,
-                Marker::Ext16 => read_u16(&mut self.rd)? as u32,
-                Marker::Ext32 => read_u32(&mut self.rd)? as u32,
-                _ => return Err(Error::TypeMismatch(marker)),
+                Marker::FixExt1 => {
+                    1 as u32
+                }
+                Marker::FixExt2 => {
+                    2 as u32
+                }
+                Marker::FixExt4 => {
+                    4 as u32
+                }
+                Marker::FixExt8 => {
+                    8 as u32
+                }
+                Marker::FixExt16 => {
+                    16 as u32
+                }
+                Marker::Ext8 => {
+                    read_u8(&mut self.rd)? as u32
+                }
+                Marker::Ext16 => {
+                    read_u16(&mut self.rd)? as u32
+                }
+                Marker::Ext32 => {
+                    read_u32(&mut self.rd)? as u32
+                }
+                _ => {
+                    return Err(Error::TypeMismatch(marker))
+                }
             };
 
             let ext_de = ExtDeserializer::new(self, len);
@@ -662,13 +640,8 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
         visitor.visit_newtype_struct(self)
     }
 
-    fn deserialize_unit_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor<'de>
     {
         // We need to special case this so that [] is treated as a unit struct when asked for,
         // but as a sequence otherwise. This is because we serialize unit structs as [] rather
@@ -705,8 +678,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         // This special case allows us to decode some integer types as floats when safe, and
         // asked for.
@@ -731,8 +703,7 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de>
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         // This special case allows us to decode some integer types as floats when safe, and
         // asked for. This is here to be consistent with 'f32'.
@@ -771,18 +742,18 @@ struct SeqAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> SeqAccess<'a, R, C> {
     fn new(de: &'a mut Deserializer<R, C>, len: usize) -> Self {
-        SeqAccess { de, left: len }
+        SeqAccess {
+            de,
+            left: len,
+        }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de>
-    for SeqAccess<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::SeqAccess<'de> for SeqAccess<'a, R, C> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
+        where T: DeserializeSeed<'de>
     {
         if self.left > 0 {
             self.left -= 1;
@@ -804,18 +775,18 @@ struct MapAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> MapAccess<'a, R, C> {
     fn new(de: &'a mut Deserializer<R, C>, len: usize) -> Self {
-        MapAccess { de, left: len }
+        MapAccess {
+            de,
+            left: len,
+        }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de>
-    for MapAccess<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de> for MapAccess<'a, R, C> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
+        where K: DeserializeSeed<'de>
     {
         if self.left > 0 {
             self.left -= 1;
@@ -826,8 +797,7 @@ impl<'de, 'a, R: ReadSlice<'de> + 'a, C: SerializerConfig> de::MapAccess<'de>
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-    where
-        V: DeserializeSeed<'de>,
+        where V: DeserializeSeed<'de>
     {
         Ok(seed.deserialize(&mut *self.de)?)
     }
@@ -843,27 +813,24 @@ struct VariantAccess<'a, R, C> {
 
 impl<'a, R: 'a, C> VariantAccess<'a, R, C> {
     pub fn new(de: &'a mut Deserializer<R, C>) -> Self {
-        VariantAccess { de }
+        VariantAccess {
+            de,
+        }
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::EnumAccess<'de>
-    for VariantAccess<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::EnumAccess<'de> for VariantAccess<'a, R, C> {
     type Error = Error;
     type Variant = Self;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), Error>
-    where
-        V: de::DeserializeSeed<'de>,
+        where V: de::DeserializeSeed<'de>,
     {
         Ok((seed.deserialize(&mut *self.de)?, self))
     }
 }
 
-impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de>
-    for VariantAccess<'a, R, C>
-{
+impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de> for VariantAccess<'a, R, C> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
@@ -872,26 +839,19 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> de::VariantAccess<'de>
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
+        where T: DeserializeSeed<'de>
     {
         seed.deserialize(self.de)
     }
 
     fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         de::Deserializer::deserialize_tuple(self.de, len, visitor)
     }
 
-    fn struct_variant<V>(
-        self,
-        fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
+        where V: Visitor<'de>
     {
         de::Deserializer::deserialize_tuple(self.de, fields.len(), visitor)
     }
@@ -963,7 +923,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ReadRefReader<'a, T> {
     fn new(rd: &'a T) -> Self {
         Self {
             rd,
-            buf: rd.as_ref(),
+            buf: rd.as_ref()
         }
     }
 }
@@ -998,15 +958,9 @@ fn test_as_ref_reader() {
     let mut rd = ReadRefReader::new(&buf);
 
     assert_eq!(rd.read_slice(1).unwrap(), Reference::Borrowed(&[0][..]));
-    assert_eq!(
-        rd.read_slice(6).unwrap(),
-        Reference::Borrowed(&[1, 2, 3, 4, 5, 6][..])
-    );
+    assert_eq!(rd.read_slice(6).unwrap(), Reference::Borrowed(&[1, 2, 3, 4, 5, 6][..]));
     assert!(rd.read_slice(5).is_err());
-    assert_eq!(
-        rd.read_slice(4).unwrap(),
-        Reference::Borrowed(&[7, 8, 9, 10][..])
-    );
+    assert_eq!(rd.read_slice(4).unwrap(), Reference::Borrowed(&[7, 8, 9, 10][..]));
 }
 
 /// Deserialize an instance of type `T` from an I/O stream of MessagePack.
@@ -1017,9 +971,8 @@ fn test_as_ref_reader() {
 /// by `T`. It can also fail if the structure is correct but `T`'s implementation of `Deserialize`
 /// decides that something is wrong with the data, for example required struct fields are missing.
 pub fn from_read<R, T>(rd: R) -> Result<T, Error>
-where
-    R: Read,
-    T: DeserializeOwned,
+where R: Read,
+      T: DeserializeOwned
 {
     Deserialize::deserialize(&mut Deserializer::new(rd))
 }
@@ -1030,7 +983,7 @@ where
 #[doc(hidden)]
 pub fn from_slice<'a, T>(input: &'a [u8]) -> Result<T, Error>
 where
-    T: Deserialize<'a>,
+    T: Deserialize<'a>
 {
     from_read_ref(input)
 }

--- a/rmp-serde/src/encode.rs
+++ b/rmp-serde/src/encode.rs
@@ -5,18 +5,16 @@ use std::fmt::{self, Display};
 use std::io::Write;
 
 use serde;
-use serde::ser::{
-    SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
-    SerializeTupleStruct, SerializeTupleVariant,
-};
 use serde::Serialize;
+use serde::ser::{SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+                 SerializeTuple, SerializeTupleStruct, SerializeTupleVariant};
 
 use rmp::encode;
 use rmp::encode::ValueWriteError;
 
 use crate::config::{
-    BinaryConfig, DefaultConfig, HumanReadableConfig, SerializerConfig, StructMapConfig,
-    StructTupleConfig, VariantIntegerConfig, VariantStringConfig,
+    DefaultConfig, SerializerConfig, StructMapConfig, StructTupleConfig, VariantIntegerConfig,
+    VariantStringConfig, HumanReadableConfig, BinaryConfig,
 };
 use crate::MSGPACK_EXT_STRUCT_NAME;
 
@@ -124,6 +122,7 @@ pub struct Serializer<W, C = DefaultConfig> {
     config: C,
     depth: usize,
 }
+
 
 impl<W: Write, C> Serializer<W, C> {
     /// Gets a reference to the underlying writer.
@@ -306,14 +305,14 @@ pub struct Compound<'a, W: 'a, C: 'a> {
 pub struct ExtFieldSerializer<'a, W> {
     wr: &'a mut W,
     tag: Option<i8>,
-    finish: bool,
+    finish: bool
 }
 
 /// Represents MessagePack serialization implementation for Ext.
 #[derive(Debug)]
 pub struct ExtSerializer<'a, W> {
     fields_se: ExtFieldSerializer<'a, W>,
-    tuple_received: bool,
+    tuple_received: bool
 }
 
 impl<'a, W: Write + 'a, C: SerializerConfig> SerializeSeq for Compound<'a, W, C> {
@@ -389,11 +388,9 @@ impl<'a, W: Write + 'a, C: SerializerConfig> SerializeStruct for Compound<'a, W,
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error> {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) ->
+        Result<(), Self::Error>
+    {
         C::write_struct_field(&mut *self.se, key, value)
     }
 
@@ -406,11 +403,9 @@ impl<'a, W: Write + 'a, C: SerializerConfig> SerializeStructVariant for Compound
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error> {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) ->
+        Result<(), Self::Error>
+    {
         C::write_struct_field(&mut *self.se, key, value)
     }
 
@@ -461,10 +456,10 @@ where
         Ok(())
     }
 
-    #[cfg(feature = "serde128")]
-    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        self.serialize_bytes(&v.to_be_bytes())
-    }
+	#[cfg(feature = "serde128")]
+	fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+		self.serialize_bytes(&v.to_be_bytes())
+	}
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
         self.serialize_u64(v as u64)
@@ -483,7 +478,7 @@ where
         Ok(())
     }
 
-    #[cfg(feature = "serde128")]
+	#[cfg(feature = "serde128")]
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
         self.serialize_bytes(&v.to_be_bytes())
     }
@@ -534,23 +529,16 @@ where
         Ok(())
     }
 
-    fn serialize_unit_variant(
-        self,
-        _name: &str,
-        idx: u32,
-        variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn serialize_unit_variant(self, _name: &str, idx: u32, variant: &'static str) ->
+        Result<Self::Ok, Self::Error>
+    {
         // encode as a map from variant idx to nil, like: {idx => nil}
         encode::write_map_len(&mut self.wr, 1)?;
         C::write_variant_ident(self, idx, variant)?;
         self.serialize_unit()
     }
 
-    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(
-        self,
-        name: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error> {
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(self, name: &'static str, value: &T) -> Result<(), Self::Error> {
         if name == MSGPACK_EXT_STRUCT_NAME {
             let mut ext_se = ExtSerializer::new(self);
             value.serialize(&mut ext_se)?;
@@ -562,13 +550,7 @@ where
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
-        self,
-        _name: &'static str,
-        idx: u32,
-        variant: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error> {
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(self, _name: &'static str, idx: u32, variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error> {
         // encode as a map from variant idx to its attributed data, like: {idx => value}
         encode::write_map_len(&mut self.wr, 1)?;
         C::write_variant_ident(self, idx, variant)?;
@@ -590,23 +572,17 @@ where
         self.serialize_seq(Some(len))
     }
 
-    fn serialize_tuple_struct(
-        self,
-        _name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+    fn serialize_tuple_struct(self, _name: &'static str, len: usize) ->
+        Result<Self::SerializeTupleStruct, Self::Error>
+    {
         encode::write_array_len(&mut self.wr, len as u32)?;
 
         self.compound()
     }
 
-    fn serialize_tuple_variant(
-        self,
-        _name: &'static str,
-        idx: u32,
-        variant: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Error> {
+    fn serialize_tuple_variant(self, _name: &'static str, idx: u32, variant: &'static str, len: usize) ->
+        Result<Self::SerializeTupleVariant, Error>
+    {
         // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
         encode::write_map_len(&mut self.wr, 1)?;
         C::write_variant_ident(self, idx, variant)?;
@@ -623,22 +599,16 @@ where
         }
     }
 
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
+    fn serialize_struct(self, _name: &'static str, len: usize) ->
+        Result<Self::SerializeStruct, Self::Error>
+    {
         C::write_struct_len(self, len)?;
         self.compound()
     }
 
-    fn serialize_struct_variant(
-        self,
-        name: &'static str,
-        id: u32,
-        variant: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStructVariant, Error> {
+    fn serialize_struct_variant(self, name: &'static str, id: u32, variant: &'static str, len: usize) ->
+        Result<Self::SerializeStructVariant, Error>
+    {
         // encode as a map from variant idx to a sequence of its attributed data, like: {idx => [v1,...,vN]}
         encode::write_map_len(&mut self.wr, 1)?;
         C::write_variant_ident(self, id, variant)?;
@@ -664,9 +634,7 @@ impl<'a, W: Write + 'a> serde::Serializer for &mut ExtFieldSerializer<'a, W> {
             self.tag.replace(value);
             Ok(())
         } else {
-            Err(Error::InvalidDataModel(
-                "expected i8 and bytes, unexpected second i8",
-            ))
+            Err(Error::InvalidDataModel("expected i8 and bytes, unexpected second i8"))
         }
     }
 
@@ -682,228 +650,136 @@ impl<'a, W: Write + 'a> serde::Serializer for &mut ExtFieldSerializer<'a, W> {
 
             Ok(())
         } else {
-            Err(Error::InvalidDataModel(
-                "expected i8 and bytes, received bytes first",
-            ))
+            Err(Error::InvalidDataModel("expected i8 and bytes, received bytes first"))
         }
     }
 
     #[inline]
     fn serialize_bool(self, _val: bool) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, bool unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, bool unexpected"))
     }
 
     #[inline]
     fn serialize_i16(self, _val: i16) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, i16 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, i16 unexpected"))
     }
 
     #[inline]
     fn serialize_i32(self, _val: i32) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, i32 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, i32 unexpected"))
     }
 
     #[inline]
     fn serialize_i64(self, _val: i64) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, i64 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, i64 unexpected"))
     }
 
     #[inline]
     fn serialize_u8(self, _val: u8) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, u8 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, u8 unexpected"))
     }
 
     #[inline]
     fn serialize_u16(self, _val: u16) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, u16 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, u16 unexpected"))
     }
 
     #[inline]
     fn serialize_u32(self, _val: u32) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, u32 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, u32 unexpected"))
     }
 
     #[inline]
     fn serialize_u64(self, _val: u64) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, u64 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, u64 unexpected"))
     }
 
     #[inline]
     fn serialize_f32(self, _val: f32) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, f32 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, f32 unexpected"))
     }
 
     #[inline]
     fn serialize_f64(self, _val: f64) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, f64 unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, f64 unexpected"))
     }
 
     #[inline]
     fn serialize_char(self, _val: char) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, char unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, char unexpected"))
     }
 
     #[inline]
     fn serialize_str(self, _val: &str) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, str unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, str unexpected"))
     }
 
     #[inline]
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, unit unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, unit unexpected"))
     }
 
     #[inline]
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, unit struct unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, unit struct unexpected"))
     }
 
     #[inline]
-    fn serialize_unit_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, unit variant unexpected",
-        ))
+    fn serialize_unit_variant(self, _name: &'static str, _idx: u32, _variant: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidDataModel("expected i8 and bytes, unit variant unexpected"))
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
     {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, newtype struct unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, newtype struct unexpected"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+    fn serialize_newtype_variant<T: ?Sized>(self, _name: &'static str, _idx: u32, _variant: &'static str, _value: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
     {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, newtype variant unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, newtype variant unexpected"))
     }
 
     #[inline]
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, none unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, none unexpected"))
     }
 
     #[inline]
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+        where T: Serialize
     {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, some unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, some unexpected"))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, seq unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, seq unexpected"))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, tuple unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, tuple unexpected"))
     }
 
-    fn serialize_tuple_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, tuple struct unexpected",
-        ))
+    fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeTupleStruct, Error> {
+        Err(Error::InvalidDataModel("expected i8 and bytes, tuple struct unexpected"))
     }
 
-    fn serialize_tuple_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, tuple variant unexpected",
-        ))
+    fn serialize_tuple_variant(self, _name: &'static str, _idx: u32, _variant: &'static str, _len: usize) -> Result<Self::SerializeTupleVariant, Error> {
+        Err(Error::InvalidDataModel("expected i8 and bytes, tuple variant unexpected"))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, map unexpected",
-        ))
+        Err(Error::InvalidDataModel("expected i8 and bytes, map unexpected"))
     }
 
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStruct, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, struct unexpected",
-        ))
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct, Error> {
+        Err(Error::InvalidDataModel("expected i8 and bytes, struct unexpected"))
     }
 
-    fn serialize_struct_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStructVariant, Error> {
-        Err(Error::InvalidDataModel(
-            "expected i8 and bytes, struct variant unexpected",
-        ))
+    fn serialize_struct_variant(self, _name: &'static str, _idx: u32, _variant: &'static str, _len: usize) -> Result<Self::SerializeStructVariant, Error> {
+        Err(Error::InvalidDataModel("expected i8 and bytes, struct variant unexpected"))
     }
 }
 
@@ -918,6 +794,7 @@ impl<'a, W: Write + 'a> serde::ser::Serializer for &mut ExtSerializer<'a, W> {
     type SerializeMap = serde::ser::Impossible<(), Error>;
     type SerializeStruct = serde::ser::Impossible<(), Error>;
     type SerializeStructVariant = serde::ser::Impossible<(), Error>;
+
 
     #[inline]
     fn serialize_bytes(self, _val: &[u8]) -> Result<Self::Ok, Self::Error> {
@@ -996,50 +873,25 @@ impl<'a, W: Write + 'a> serde::ser::Serializer for &mut ExtSerializer<'a, W> {
 
     #[inline]
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received unit_struct",
-        ))
+        Err(Error::InvalidDataModel("expected tuple, received unit_struct"))
     }
 
     #[inline]
-    fn serialize_unit_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received unit_variant",
-        ))
+    fn serialize_unit_variant(self, _name: &'static str, _idx: u32, _variant: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidDataModel("expected tuple, received unit_variant"))
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
     {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received newtype_struct",
-        ))
+        Err(Error::InvalidDataModel("expected tuple, received newtype_struct"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+    fn serialize_newtype_variant<T: ?Sized>(self, _name: &'static str, _idx: u32, _variant: &'static str, _value: &T) -> Result<Self::Ok, Self::Error>
+        where T: Serialize
     {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received newtype_variant",
-        ))
+        Err(Error::InvalidDataModel("expected tuple, received newtype_variant"))
     }
 
     #[inline]
@@ -1049,8 +901,7 @@ impl<'a, W: Write + 'a> serde::ser::Serializer for &mut ExtSerializer<'a, W> {
 
     #[inline]
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
+        where T: Serialize
     {
         Err(Error::InvalidDataModel("expected tuple, received some"))
     }
@@ -1066,50 +917,24 @@ impl<'a, W: Write + 'a> serde::ser::Serializer for &mut ExtSerializer<'a, W> {
         Ok(self)
     }
 
-    fn serialize_tuple_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Error> {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received tuple_struct",
-        ))
+    fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeTupleStruct, Error> {
+        Err(Error::InvalidDataModel("expected tuple, received tuple_struct"))
     }
 
-    fn serialize_tuple_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Error> {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received tuple_variant",
-        ))
+    fn serialize_tuple_variant(self, _name: &'static str, _idx: u32, _variant: &'static str, _len: usize) -> Result<Self::SerializeTupleVariant, Error> {
+        Err(Error::InvalidDataModel("expected tuple, received tuple_variant"))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
         Err(Error::InvalidDataModel("expected tuple, received map"))
     }
 
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStruct, Error> {
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct, Error> {
         Err(Error::InvalidDataModel("expected tuple, received struct"))
     }
 
-    fn serialize_struct_variant(
-        self,
-        _name: &'static str,
-        _idx: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStructVariant, Error> {
-        Err(Error::InvalidDataModel(
-            "expected tuple, received struct_variant",
-        ))
+    fn serialize_struct_variant(self, _name: &'static str, _idx: u32, _variant: &'static str, _len: usize) -> Result<Self::SerializeStructVariant, Error> {
+        Err(Error::InvalidDataModel("expected tuple, received struct_variant"))
     }
 }
 
@@ -1126,11 +951,12 @@ impl<'a, W: Write + 'a> SerializeTuple for &mut ExtSerializer<'a, W> {
     }
 }
 
+
 impl<'a, W: Write + 'a> ExtSerializer<'a, W> {
     fn new<C>(ser: &'a mut Serializer<W, C>) -> Self {
         Self {
             fields_se: ExtFieldSerializer::new(ser),
-            tuple_received: false,
+            tuple_received: false
         }
     }
 
@@ -1146,9 +972,9 @@ impl<'a, W: Write + 'a> ExtSerializer<'a, W> {
 impl<'a, W: Write + 'a> ExtFieldSerializer<'a, W> {
     fn new<C>(ser: &'a mut Serializer<W, C>) -> Self {
         Self {
-            wr: UnderlyingWrite::get_mut(ser),
-            tag: None,
-            finish: false,
+           wr: UnderlyingWrite::get_mut(ser),
+           tag: None,
+           finish: false
         }
     }
 
@@ -1169,7 +995,7 @@ impl<'a, W: Write + 'a> ExtFieldSerializer<'a, W> {
 pub fn write<W, T>(wr: &mut W, val: &T) -> Result<(), Error>
 where
     W: Write + ?Sized,
-    T: Serialize + ?Sized,
+    T: Serialize + ?Sized
 {
     val.serialize(&mut Serializer::new(wr))
 }
@@ -1182,9 +1008,10 @@ where
 pub fn write_named<W, T>(wr: &mut W, val: &T) -> Result<(), Error>
 where
     W: Write + ?Sized,
-    T: Serialize + ?Sized,
+    T: Serialize + ?Sized
 {
-    let mut se = Serializer::new(wr).with_struct_map();
+    let mut se = Serializer::new(wr)
+        .with_struct_map();
     val.serialize(&mut se)
 }
 
@@ -1195,7 +1022,7 @@ where
 #[inline]
 pub fn to_vec<T>(val: &T) -> Result<Vec<u8>, Error>
 where
-    T: Serialize + ?Sized,
+    T: Serialize + ?Sized
 {
     let mut wr = Vec::with_capacity(128);
     write(&mut wr, val)?;
@@ -1211,7 +1038,7 @@ where
 #[inline]
 pub fn to_vec_named<T>(val: &T) -> Result<Vec<u8>, Error>
 where
-    T: Serialize + ?Sized,
+    T: Serialize + ?Sized
 {
     let mut wr = Vec::with_capacity(128);
     write_named(&mut wr, val)?;


### PR DESCRIPTION
This fixes #169. 128-bit values are serialised as 16 bytes, representing the binary encoding in big-endian format. I've added it behind a feature gate, so it's opt-in for those who want it. If it should be always available, I can change that.