### PR TITLE
Serializing seqs and maps of unknown length (#196) 

### DIFF
--- a/rmp-serde/CHANGELOG.md
+++ b/rmp-serde/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add missing `Debug` implementations.
 - More `decode::Error` conversions.
 - Support for serializing and deserializing 128-bit values in serde.
+- Support for serializing sequences and maps with unknown length, that enables the use of `#[serde(flatten)]` attribute (#196).
 
 ### Changed:
 - (Breaking) Serialize newtype structs by serializing its inner type without wrapping into a tuple.

--- a/rmp-serde/tests/decode_derive.rs
+++ b/rmp-serde/tests/decode_derive.rs
@@ -384,6 +384,111 @@ fn pass_enum_with_one_arg() {
 }
 
 #[test]
+fn pass_struct_with_flattened_map_field() {
+    use std::collections::BTreeMap;
+
+    // The encoded bytearray is: { "f1": 0, "f2": { "german": "Hallo Welt!" }, "english": "Hello World!" }.
+    let buf = [
+        0x83, 0xA2, 0x66, 0x31, 0x00, 0xA2, 0x66, 0x32, 0x81, 0xA6, 0x67, 0x65, 0x72, 0x6D, 0x61, 0x6E, 0xAB,
+        0x48, 0x61, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x65, 0x6C, 0x74, 0x21, 0xA7, 0x65, 0x6E, 0x67, 0x6C, 0x69,
+        0x73, 0x68, 0xAC, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64, 0x21,
+    ];
+    let cur = Cursor::new(&buf[..]);
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Struct {
+        f1: u32,
+        // not flattend!
+        f2: BTreeMap<String, String>,
+        #[serde(flatten)]
+        f3: BTreeMap<String, String>
+    }
+
+    let expected = Struct {
+        f1: 0,
+        f2: {
+            let mut map = BTreeMap::new();
+            map.insert("german".to_string(), "Hallo Welt!".to_string());
+            map
+        },
+        f3: {
+            let mut map = BTreeMap::new();
+            map.insert("english".to_string(), "Hello World!".to_string());
+            map
+        }
+    };
+
+    let mut de = Deserializer::new(cur);
+    let actual: Struct = Deserialize::deserialize(&mut de).unwrap();
+
+    assert_eq!(expected, actual);
+    assert_eq!(buf.len() as u64, de.get_ref().position());
+}
+
+#[test]
+fn pass_struct_with_flattened_struct_field() {
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Struct {
+        f1: u32,
+        // not flattend!
+        f2: InnerStruct,
+        #[serde(flatten)]
+        f3: InnerStruct
+    }
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct InnerStruct {
+        f4: u32,
+        f5: u32
+    }
+
+    let expected = Struct {
+        f1: 0,
+        f2: InnerStruct {
+            f4: 8,
+            f5: 13
+        },
+        f3: InnerStruct {
+            f4: 21,
+            f5: 34
+        }
+    };
+
+    // struct-as-tuple
+    {
+        // The encoded bytearray is: { "f1": 0, "f2": [8, 13], "f4": 21, "f5": 34 }.
+        let buf = [
+            0x84, 0xA2, 0x66, 0x31, 0x00, 0xA2, 0x66, 0x32, 0x92, 0x08, 0x0D, 0xA2, 0x66, 0x34, 0x15, 0xA2, 0x66, 0x35,
+            0x22,
+        ];
+        let cur = Cursor::new(&buf[..]);
+
+        let mut de = Deserializer::new(cur);
+        let actual: Struct = Deserialize::deserialize(&mut de).unwrap();
+
+        assert_eq!(expected, actual);
+        assert_eq!(buf.len() as u64, de.get_ref().position());
+    }
+
+    // struct-as-map
+    {
+        // The encoded bytearray is: { "f1": 0, "f2": { "f4": 8, "f5": 13 }, "f4": 21, "f5": 34 }.
+        let buf = [
+            0x84, 0xA2, 0x66, 0x31, 0x00, 0xA2, 0x66, 0x32, 0x82, 0xA2, 0x66, 0x34, 0x08,
+            0xA2, 0x66, 0x35, 0x0D, 0xA2, 0x66, 0x34, 0x15, 0xA2, 0x66, 0x35, 0x22,
+        ];
+        let cur = Cursor::new(&buf[..]);
+
+        let mut de = Deserializer::new(cur);
+        let actual: Struct = Deserialize::deserialize(&mut de).unwrap();
+
+        assert_eq!(expected, actual);
+        assert_eq!(buf.len() as u64, de.get_ref().position());
+    }
+}
+
+
+#[test]
 fn pass_from_slice() {
     let buf = [0x93, 0xa4, 0x4a, 0x6f, 0x68, 0x6e, 0xa5, 0x53, 0x6d, 0x69, 0x74, 0x68, 0x2a];
 


### PR DESCRIPTION
This fixes the serialization of structs that contain fields tagged with #[serde(flatten)].
The basic idea is to write elements to another Serializer, count the elements that are
serialized, and in the end, write the counted length and the serialzed elements to the
main Serializer.

A drawback might be that such a struct cannot be written in compact representation as
serde wants to serialize it as a map.