### PR TITLE
Fix deserialization of nested Options

### DIFF
--- a/rmp-serde/CHANGELOG.md
+++ b/rmp-serde/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix error decoding `Some(enum)` (#185)
 - Fix error decoding unit structs which were encoded as `[]` (#181)
 - Fix `Display` implementations for errors not including all relevant information (#199)
+- Fix deserialization of nested `Option`s (#245)
 
 ## 0.13.7 - 2017-09-13
 ### Changed:

--- a/rmp-serde/tests/decode.rs
+++ b/rmp-serde/tests/decode.rs
@@ -274,6 +274,24 @@ fn pass_option_none() {
 }
 
 #[test]
+fn pass_nested_option_some() {
+    let buf = [0x1f];
+
+    let mut de = Deserializer::new(&buf[..]);
+    let actual: Option<Option<u8>> = Deserialize::deserialize(&mut de).unwrap();
+    assert_eq!(Some(Some(31)), actual);
+}
+
+#[test]
+fn pass_nested_option_none() {
+    let buf = [0xc0];
+
+    let mut de = Deserializer::new(&buf[..]);
+    let actual: Option<Option<u8>> = Deserialize::deserialize(&mut de).unwrap();
+    assert_eq!(None, actual);
+}
+
+#[test]
 fn fail_option_u8_from_reserved() {
     let buf = [0xc1];
     let cur = Cursor::new(&buf[..]);

--- a/rmp-serde/tests/decode_derive.rs
+++ b/rmp-serde/tests/decode_derive.rs
@@ -384,6 +384,25 @@ fn pass_enum_with_one_arg() {
 }
 
 #[test]
+fn pass_struct_with_nested_options() {
+    // The encoded bytearray is: [null, 13].
+    let buf = [0x92, 0xc0, 0x0D];
+    let cur = Cursor::new(&buf[..]);
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct Struct {
+        f1: Option<Option<u32>>,
+        f2: Option<Option<u32>>,
+    }
+
+    let mut de = Deserializer::new(cur);
+    let actual: Struct = Deserialize::deserialize(&mut de).unwrap();
+
+    assert_eq!(Struct { f1: None, f2: Some(Some(13)) }, actual);
+    assert_eq!(buf.len() as u64, de.get_ref().position());
+}
+
+#[test]
 fn pass_struct_with_flattened_map_field() {
     use std::collections::BTreeMap;
 

--- a/rmp-serde/tests/round.rs
+++ b/rmp-serde/tests/round.rs
@@ -27,6 +27,27 @@ fn round_trip_option() {
 }
 
 #[test]
+fn round_trip_nested_option() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Struct {
+        f1: Option<Option<u32>>,
+        f2: Option<Option<u32>>,
+    }
+
+    let expected = Struct {
+        f1: Some(Some(13)),
+        f2: None
+    };
+
+    let mut buf = Vec::new();
+    expected.serialize(&mut Serializer::new(&mut buf)).unwrap();
+
+    let mut de = Deserializer::new(Cursor::new(&buf[..]));
+
+    assert_eq!(expected, Deserialize::deserialize(&mut de).unwrap());
+}
+
+#[test]
 fn round_trip_optional_enum() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     pub enum SimpleEnum {


### PR DESCRIPTION
This should fix #245.
It seems like the fix is just to test if the marker has already been read and take it out before trying to read it from the reader.