### PR TITLE
fix: add stack depth checking to rmpv

### DIFF
--- a/rmpv-tests/tests/decode.rs
+++ b/rmpv-tests/tests/decode.rs
@@ -21,6 +21,18 @@ fn test_decode(buf: &[u8], v: Value) {
 }
 
 #[test]
+fn test_stack_depth_checking() {
+    let mut buf: Vec<u8> = (0..decode::MAX_DEPTH).map(|_| 0x91).collect();
+    buf.push(0xc3);
+
+    match decode::read_value(&mut &buf[..]) {
+        Ok(_) => panic!("expected max stack depth to be exceeded"),
+        Err(decode::Error::DepthLimitExceeded) => {},
+        Err(err) => panic!("unexpected error: {}", err),
+    }
+}
+
+#[test]
 fn pass_null() {
     test_decode(&[0xc0], Value::Nil);
 }

--- a/rmpv/src/decode/mod.rs
+++ b/rmpv/src/decode/mod.rs
@@ -7,8 +7,8 @@ use rmp::decode::{MarkerReadError, ValueReadError};
 pub mod value;
 pub mod value_ref;
 
-pub use self::value::{read_value, read_value_max_depth};
-pub use self::value_ref::{read_value_ref, read_value_ref_max_depth};
+pub use self::value::{read_value, read_value_with_max_depth};
+pub use self::value_ref::{read_value_ref, read_value_ref_with_max_depth};
 
 /// The maximum recursion depth before [`Error::DepthLimitExceeded`] is returned.
 pub const MAX_DEPTH: usize = 1024;

--- a/rmpv/src/decode/mod.rs
+++ b/rmpv/src/decode/mod.rs
@@ -7,8 +7,8 @@ use rmp::decode::{MarkerReadError, ValueReadError};
 pub mod value;
 pub mod value_ref;
 
-pub use self::value::read_value;
-pub use self::value_ref::read_value_ref;
+pub use self::value::{read_value, read_value_max_depth};
+pub use self::value_ref::{read_value_ref, read_value_ref_max_depth};
 
 /// The maximum recursion depth before [`Error::DepthLimitExceeded`] is returned.
 pub const MAX_DEPTH: usize = 1024;

--- a/rmpv/src/decode/mod.rs
+++ b/rmpv/src/decode/mod.rs
@@ -11,7 +11,7 @@ pub use self::value::read_value;
 pub use self::value_ref::read_value_ref;
 
 /// The maximum recursion depth before [`Error::DepthLimitExceeded`] is returned.
-pub const MAX_DEPTH: usize = 256;
+pub const MAX_DEPTH: usize = 1024;
 
 /// This type represents all possible errors that can occur when deserializing a value.
 #[derive(Debug)]
@@ -24,11 +24,11 @@ pub enum Error {
     DepthLimitExceeded,
 }
 
-fn increment_depth(depth: usize) -> Result<usize, Error> {
-    if depth == MAX_DEPTH {
+fn decrement_depth(depth: usize) -> Result<usize, Error> {
+    if depth == 0 {
         Err(Error::DepthLimitExceeded)
     } else {
-        Ok(depth + 1)
+        Ok(depth - 1)
     }
 }
 

--- a/rmpv/src/decode/mod.rs
+++ b/rmpv/src/decode/mod.rs
@@ -10,6 +10,9 @@ pub mod value_ref;
 pub use self::value::read_value;
 pub use self::value_ref::read_value_ref;
 
+/// The maximum recursion depth before [`Error::DepthLimitExceeded`] is returned.
+pub const MAX_DEPTH: usize = 256;
+
 /// This type represents all possible errors that can occur when deserializing a value.
 #[derive(Debug)]
 pub enum Error {
@@ -17,6 +20,16 @@ pub enum Error {
     InvalidMarkerRead(io::Error),
     /// Error while reading data.
     InvalidDataRead(io::Error),
+    /// The depth limit [`MAX_DEPTH`] was exceeded.
+    DepthLimitExceeded,
+}
+
+fn increment_depth(depth: usize) -> Result<usize, Error> {
+    if depth == MAX_DEPTH {
+        Err(Error::DepthLimitExceeded)
+    } else {
+        Ok(depth + 1)
+    }
 }
 
 impl Error {
@@ -25,6 +38,7 @@ impl Error {
         match *self {
             Error::InvalidMarkerRead(ref err) => err.kind(),
             Error::InvalidDataRead(ref err) => err.kind(),
+            Error::DepthLimitExceeded => ErrorKind::Unsupported,
         }
     }
 }
@@ -35,6 +49,7 @@ impl error::Error for Error {
         match *self {
             Error::InvalidMarkerRead(ref err) => Some(err),
             Error::InvalidDataRead(ref err) => Some(err),
+            Error::DepthLimitExceeded => None,
         }
     }
 }
@@ -48,6 +63,9 @@ impl Display for Error {
             }
             Error::InvalidDataRead(ref err) => {
                 write!(fmt, "I/O error while reading non-marker bytes: {}", err)
+            }
+            Error::DepthLimitExceeded => {
+                write!(fmt, "depth limit exceeded")
             }
         }
     }
@@ -79,6 +97,7 @@ impl Into<io::Error> for Error {
         match self {
             Error::InvalidMarkerRead(err) |
             Error::InvalidDataRead(err) => err,
+            Error::DepthLimitExceeded => io::Error::new(self.kind(), self),
         }
     }
 }

--- a/rmpv/src/decode/value.rs
+++ b/rmpv/src/decode/value.rs
@@ -14,34 +14,40 @@ use super::Error;
 const PREALLOC_MAX: usize = 64 * 1024; // 64 KiB
 
 
-fn read_array_data<R: Read>(rd: &mut R, mut len: usize) -> Result<Vec<Value>, Error> {
+fn read_array_data<R: Read>(rd: &mut R, mut len: usize, depth: usize) -> Result<Vec<Value>, Error> {
+    let depth = super::increment_depth(depth)?;
+
     // Note: Do not preallocate a Vec of size `len`.
     // See https://github.com/3Hren/msgpack-rust/issues/151
     let mut vec = Vec::new();
 
     while len > 0 {
-        vec.push(read_value(rd)?);
+        vec.push(read_value_inner(rd, depth)?);
         len -= 1;
     }
 
     Ok(vec)
 }
 
-fn read_map_data<R: Read>(rd: &mut R, mut len: usize) -> Result<Vec<(Value, Value)>, Error> {
+fn read_map_data<R: Read>(rd: &mut R, mut len: usize, depth: usize) -> Result<Vec<(Value, Value)>, Error> {
+    let depth = super::increment_depth(depth)?;
+
     // Note: Do not preallocate a Vec of size `len`.
     // See https://github.com/3Hren/msgpack-rust/issues/151
     let mut vec = Vec::new();
 
     while len > 0 {
-        vec.push((read_value(rd)?, read_value(rd)?));
+        vec.push((read_value_inner(rd, depth)?, read_value_inner(rd, depth)?));
         len -= 1;
     }
 
     Ok(vec)
 }
 
-fn read_str_data<R: Read>(rd: &mut R, len: usize) -> Result<Utf8String, Error> {
-    match String::from_utf8(read_bin_data(rd, len)?) {
+fn read_str_data<R: Read>(rd: &mut R, len: usize, depth: usize) -> Result<Utf8String, Error> {
+    let depth = super::increment_depth(depth)?;
+
+    match String::from_utf8(read_bin_data(rd, len, depth)?) {
         Ok(s) => Ok(Utf8String::from(s)),
         Err(err) => {
             let e = err.utf8_error();
@@ -53,7 +59,9 @@ fn read_str_data<R: Read>(rd: &mut R, len: usize) -> Result<Utf8String, Error> {
     }
 }
 
-fn read_bin_data<R: Read>(rd: &mut R, len: usize) -> Result<Vec<u8>, Error> {
+fn read_bin_data<R: Read>(rd: &mut R, len: usize, depth: usize) -> Result<Vec<u8>, Error> {
+    let _depth = super::increment_depth(depth)?;
+
     let mut buf = Vec::with_capacity(min(len, PREALLOC_MAX));
     let bytes_read = rd.take(len as u64).read_to_end(&mut buf).map_err(Error::InvalidDataRead)?;
     if bytes_read != len {
@@ -66,24 +74,17 @@ fn read_bin_data<R: Read>(rd: &mut R, len: usize) -> Result<Vec<u8>, Error> {
     Ok(buf)
 }
 
-fn read_ext_body<R: Read>(rd: &mut R, len: usize) -> Result<(i8, Vec<u8>), Error> {
+fn read_ext_body<R: Read>(rd: &mut R, len: usize, depth: usize) -> Result<(i8, Vec<u8>), Error> {
+    let depth = super::increment_depth(depth)?;
+
     let ty = read_data_i8(rd)?;
-    let vec = read_bin_data(rd, len)?;
+    let vec = read_bin_data(rd, len, depth)?;
 
     Ok((ty, vec))
 }
 
-/// Attempts to read bytes from the given reader and interpret them as a `Value`.
-///
-/// # Errors
-///
-/// This function will return `Error` on any I/O error while either reading or decoding a `Value`.
-/// All instances of `ErrorKind::Interrupted` are handled by this function and the underlying
-/// operation is retried.
-#[inline(never)]
-pub fn read_value<R>(rd: &mut R) -> Result<Value, Error>
-    where R: Read
-{
+fn read_value_inner<R>(rd: &mut R, depth: usize) -> Result<Value, Error> where R: Read {
+    let depth = super::increment_depth(depth)?;
     let val = match read_marker(rd)? {
         Marker::Null => Value::Nil,
         Marker::True => Value::Boolean(true),
@@ -101,109 +102,123 @@ pub fn read_value<R>(rd: &mut R) -> Result<Value, Error>
         Marker::F32 => Value::F32(read_data_f32(rd)?),
         Marker::F64 => Value::F64(read_data_f64(rd)?),
         Marker::FixStr(len) => {
-            let res = read_str_data(rd, len as usize)?;
+            let res = read_str_data(rd, len as usize, depth)?;
             Value::String(res)
         }
         Marker::Str8 => {
             let len = read_data_u8(rd)?;
-            let res = read_str_data(rd, len as usize)?;
+            let res = read_str_data(rd, len as usize, depth)?;
             Value::String(res)
         }
         Marker::Str16 => {
             let len = read_data_u16(rd)?;
-            let res = read_str_data(rd, len as usize)?;
+            let res = read_str_data(rd, len as usize, depth)?;
             Value::String(res)
         }
         Marker::Str32 => {
             let len = read_data_u32(rd)?;
-            let res = read_str_data(rd, len as usize)?;
+            let res = read_str_data(rd, len as usize, depth)?;
             Value::String(res)
         }
         Marker::FixArray(len) => {
-            let vec = read_array_data(rd, len as usize)?;
+            let vec = read_array_data(rd, len as usize, depth)?;
             Value::Array(vec)
         }
         Marker::Array16 => {
             let len = read_data_u16(rd)?;
-            let vec = read_array_data(rd, len as usize)?;
+            let vec = read_array_data(rd, len as usize, depth)?;
             Value::Array(vec)
         }
         Marker::Array32 => {
             let len = read_data_u32(rd)?;
-            let vec = read_array_data(rd, len as usize)?;
+            let vec = read_array_data(rd, len as usize, depth)?;
             Value::Array(vec)
         }
         Marker::FixMap(len) => {
-            let map = read_map_data(rd, len as usize)?;
+            let map = read_map_data(rd, len as usize, depth)?;
             Value::Map(map)
         }
         Marker::Map16 => {
             let len = read_data_u16(rd)?;
-            let map = read_map_data(rd, len as usize)?;
+            let map = read_map_data(rd, len as usize, depth)?;
             Value::Map(map)
         }
         Marker::Map32 => {
             let len = read_data_u32(rd)?;
-            let map = read_map_data(rd, len as usize)?;
+            let map = read_map_data(rd, len as usize, depth)?;
             Value::Map(map)
         }
         Marker::Bin8 => {
             let len = read_data_u8(rd)?;
-            let vec = read_bin_data(rd, len as usize)?;
+            let vec = read_bin_data(rd, len as usize, depth)?;
             Value::Binary(vec)
         }
         Marker::Bin16 => {
             let len = read_data_u16(rd)?;
-            let vec = read_bin_data(rd, len as usize)?;
+            let vec = read_bin_data(rd, len as usize, depth)?;
             Value::Binary(vec)
         }
         Marker::Bin32 => {
             let len = read_data_u32(rd)?;
-            let vec = read_bin_data(rd, len as usize)?;
+            let vec = read_bin_data(rd, len as usize, depth)?;
             Value::Binary(vec)
         }
         Marker::FixExt1 => {
             let len = 1 as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::FixExt2 => {
             let len = 2 as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::FixExt4 => {
             let len = 4 as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::FixExt8 => {
             let len = 8 as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::FixExt16 => {
             let len = 16 as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::Ext8 => {
             let len = read_data_u8(rd)? as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::Ext16 => {
             let len = read_data_u16(rd)? as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::Ext32 => {
             let len = read_data_u32(rd)? as usize;
-            let (ty, vec) = read_ext_body(rd, len)?;
+            let (ty, vec) = read_ext_body(rd, len, depth)?;
             Value::Ext(ty, vec)
         }
         Marker::Reserved => Value::Nil,
     };
 
     Ok(val)
+}
+
+/// Attempts to read bytes from the given reader and interpret them as a `Value`.
+///
+/// # Errors
+///
+/// This function will return `Error` on any I/O error while either reading or decoding a `Value`.
+/// All instances of `ErrorKind::Interrupted` are handled by this function and the underlying
+/// operation is retried.
+#[inline(never)]
+pub fn read_value<R>(rd: &mut R) -> Result<Value, Error>
+    where R: Read
+{
+    read_value_inner(rd, 0)
 }

--- a/rmpv/src/decode/value.rs
+++ b/rmpv/src/decode/value.rs
@@ -214,12 +214,12 @@ fn read_value_inner<R>(rd: &mut R, depth: usize) -> Result<Value, Error> where R
 /// # Errors
 ///
 /// This function will return [`Error`] on any I/O error while either reading or decoding a [`Value`].
-/// All instances of [`ErrorKind::Interrupted`] are handled by this function and the underlying
-/// operation is retried.
+/// All instances of [`ErrorKind::Interrupted`](io::ErrorKind) are handled by this function and the
+/// underlying operation is retried.
 ///
 /// [`Error::DepthLimitExceeded`] is returned if this function recurses
 /// [`MAX_DEPTH`](super::MAX_DEPTH) times. To configure the maximum recursion depth, use
-/// [`read_value_max_depth`] instead.
+/// [`read_value_with_max_depth`] instead.
 #[inline(never)]
 pub fn read_value<R>(rd: &mut R) -> Result<Value, Error>
     where R: Read
@@ -232,14 +232,14 @@ pub fn read_value<R>(rd: &mut R) -> Result<Value, Error>
 /// # Errors
 ///
 /// This function will return [`Error`] on any I/O error while either reading or decoding a [`Value`].
-/// All instances of [`ErrorKind::Interrupted`] are handled by this function and the underlying
-/// operation is retried.
+/// All instances of [`ErrorKind::Interrupted`](io::ErrorKind) are handled by this function and the
+/// underlying operation is retried.
 ///
 /// [`Error::DepthLimitExceeded`] is returned if this function recurses
 /// `max_depth` times. If the default [`MAX_DEPTH`](super::MAX_DEPTH) is sufficient or you do not
 /// need recursion depth checking for your data, consider using [`read_value`] instead.
 #[inline(never)]
-pub fn read_value_max_depth<R>(rd: &mut R, max_depth: usize) -> Result<Value, Error>
+pub fn read_value_with_max_depth<R>(rd: &mut R, max_depth: usize) -> Result<Value, Error>
     where R: Read
 {
     read_value_inner(rd, max_depth)   

--- a/rmpv/src/decode/value_ref.rs
+++ b/rmpv/src/decode/value_ref.rs
@@ -282,7 +282,7 @@ fn read_value_ref_inner<'a, R>(rd: &mut R, depth: usize) -> Result<ValueRef<'a>,
 ///
 /// This function enforces a maximum recursion depth of [`MAX_DEPTH`](super::MAX_DEPTH) and returns
 /// [`Error::DepthLimitExceeded`] if the maximum is hit. If you run into stack overflows despite
-/// this, use [`read_value_ref_max_depth`] with a custom maximum depth.
+/// this, use [`read_value_ref_with_max_depth`] with a custom maximum depth.
 ///
 /// # Examples
 /// ```
@@ -315,7 +315,7 @@ pub fn read_value_ref<'a, R>(rd: &mut R) -> Result<ValueRef<'a>, Error>
 /// Same as [`read_value_ref`], using the `max_depth` parameter in place of
 /// [`MAX_DEPTH`](super::MAX_DEPTH).
 #[inline(never)]
-pub fn read_value_ref_max_depth<'a, R>(rd: &mut R, max_depth: usize) -> Result<ValueRef<'a>, Error>
+pub fn read_value_ref_with_max_depth<'a, R>(rd: &mut R, max_depth: usize) -> Result<ValueRef<'a>, Error>
     where R: BorrowRead<'a>
 {
     read_value_ref_inner(rd, max_depth)


### PR DESCRIPTION
This should resolve #281.

The constant `MAX_DEPTH` came from running `cargo test` on the computer I developed this on. `256` was the largest power of 2 that did not cause a stack overflow, so that seemed good enough. This should allow at least 100 nested structures, if I figure correctly.

Let me know if there is anything to fix, add, or remove.