### PR TITLE
Experimental: Support no_std for bytes

### DIFF
--- a/rmp/Cargo.toml
+++ b/rmp/Cargo.toml
@@ -12,8 +12,15 @@ categories = ["encoding"]
 edition = "2018"
 
 [dependencies]
-byteorder = "1.4.2"
-num-traits = "0.2.14"
+byteorder = { version = "1.4.2", default-features = false }
+num-traits = { version = "0.2.14", default-features = false }
+# This is macro_only ;)
+paste = "1.0"
+
+
+[features]
+default = ["std"]
+std = ["byteorder/std", "num-traits/std"]
 
 [dev-dependencies]
 quickcheck = "1.0.2"

--- a/rmp/src/encode/dec.rs
+++ b/rmp/src/encode/dec.rs
@@ -1,6 +1,4 @@
-use std::io::Write;
-
-use super::{write_data_f32, write_data_f64, write_marker};
+use super::{RmpWrite, write_marker};
 use crate::encode::ValueWriteError;
 use crate::Marker;
 
@@ -12,9 +10,9 @@ use crate::Marker;
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_f32<W: Write>(wr: &mut W, val: f32) -> Result<(), ValueWriteError> {
+pub fn write_f32<W: RmpWrite>(wr: &mut W, val: f32) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::F32)?;
-    write_data_f32(wr, val)?;
+    wr.write_data_f32(val)?;
     Ok(())
 }
 
@@ -26,8 +24,8 @@ pub fn write_f32<W: Write>(wr: &mut W, val: f32) -> Result<(), ValueWriteError> 
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_f64<W: Write>(wr: &mut W, val: f64) -> Result<(), ValueWriteError> {
+pub fn write_f64<W: RmpWrite>(wr: &mut W, val: f64) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::F64)?;
-    write_data_f64(wr, val)?;
+    wr.write_data_f64(val)?;
     Ok(())
 }

--- a/rmp/src/encode/mod.rs
+++ b/rmp/src/encode/mod.rs
@@ -15,59 +15,101 @@ pub use self::sint::{write_i16, write_i32, write_i64, write_i8, write_nfix, writ
 pub use self::str::{write_str, write_str_len};
 pub use self::uint::{write_pfix, write_u16, write_u32, write_u64, write_u8, write_uint};
 
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt::{self, Display, Formatter};
+use alloc::vec::Vec;
+use core::fmt::{self, Display, Debug, Formatter};
+#[cfg(feature = "std")]
 use std::io::Write;
-
-use byteorder::{self, WriteBytesExt};
+use byteorder::{ByteOrder};
 
 use crate::Marker;
 
-/// The error type for I/O operations of the `Write` and associated traits.
+#[cfg(feature = "std")]
+#[deprecated(note = "Doesn't abstract over RmpWrite (or work on no_std), use RmpWrite::Error and RmpWriteErr instead")]
 pub type Error = ::std::io::Error;
 
-// An error returned from the `write_marker` and `write_fixval` functions.
-struct MarkerWriteError(Error);
+#[cfg(not(feature = "std"))]
+#[deprecated(note = "Doesn't work meaningfully on no_std")]
+pub type Error = ::core::convert::Infallible;
 
-impl From<Error> for MarkerWriteError {
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub trait MaybeErrBound: std::error::Error {}
+#[cfg(feature = "std")]
+impl<T: ?Sized + std::error::Error> MaybeErrBound for T  {}
+#[cfg(not(feature = "std"))]
+#[doc(hidden)]
+pub trait MaybeErrBound {}
+#[cfg(not(feature = "std"))]
+impl<T: ?Sized> MaybeErrBound for T  {}
+
+/// The error type for I/O operations of the `RmpWrite` and associated traits.
+///
+/// For `std::io::Write`, this is `std;:io::Error`
+pub trait RmpWriteErr: Display + Debug + MaybeErrBound + 'static {}
+#[cfg(feature = "std")]
+impl RmpWriteErr for std::io::Error {
+
+}
+impl RmpWriteErr for core::convert::Infallible {}
+
+/// A wrapper around `Vec<u8>` to serialize more efficiently.
+///
+/// This has a specialized implementation of `RmpWrite`.
+///
+/// This has the additional benefit of working on `#[no_std]`
+///
+/// See also [serde_bytes::ByteBuf](https://docs.rs/serde_bytes/0.11/serde_bytes/struct.ByteBuf.html)
+pub struct ByteBuf {
+    bytes: Vec<u8>,
+}
+
+impl RmpWrite for ByteBuf {
+    type Error = core::convert::Infallible;
+
+    #[inline]
+    fn write_u8(&mut self, val: u8) -> Result<(), Self::Error> {
+        self.bytes.push(val);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.bytes.extend_from_slice(buf);
+        Ok(())
+    }
+}
+
+
+// An error returned from the `write_marker` and `write_fixval` functions.
+struct MarkerWriteError<E: RmpWriteErr>(E);
+
+impl<E: RmpWriteErr> From<E> for MarkerWriteError<E> {
     #[cold]
-    fn from(err: Error) -> MarkerWriteError {
+    fn from(err: E) -> Self {
         MarkerWriteError(err)
     }
 }
 
-impl From<MarkerWriteError> for Error {
-    #[cold]
-    fn from(err: MarkerWriteError) -> Error {
-        match err {
-            MarkerWriteError(err) => err,
-        }
-    }
-}
 
 /// Attempts to write the given marker into the writer.
-fn write_marker<W: Write>(wr: &mut W, marker: Marker) -> Result<(), MarkerWriteError> {
+fn write_marker<W: RmpWrite>(wr: &mut W, marker: Marker) -> Result<(), MarkerWriteError<W::Error>> {
     wr.write_u8(marker.to_u8()).map_err(MarkerWriteError)
 }
 
 /// An error returned from primitive values write functions.
-struct DataWriteError(Error);
+#[doc(hidden)]
+pub struct DataWriteError<E: RmpWriteErr>(E);
 
-impl From<Error> for DataWriteError {
+impl<E: RmpWriteErr> From<E> for DataWriteError<E> {
     #[cold]
     #[inline]
-    fn from(err: Error) -> DataWriteError {
+    fn from(err: E) -> DataWriteError<E> {
         DataWriteError(err)
     }
 }
 
-impl From<DataWriteError> for Error {
-    #[cold]
-    #[inline]
-    fn from(err: DataWriteError) -> Error {
-        err.0
-    }
-}
 
 /// Encodes and attempts to write a nil value into the given write.
 ///
@@ -87,8 +129,8 @@ impl From<DataWriteError> for Error {
 /// assert_eq!(vec![0xc0], buf);
 /// ```
 #[inline]
-pub fn write_nil<W: Write>(wr: &mut W) -> Result<(), Error> {
-    write_marker(wr, Marker::Null).map_err(From::from)
+pub fn write_nil<W: RmpWrite>(wr: &mut W) -> Result<(), W::Error> {
+    write_marker(wr, Marker::Null).map_err(|e| e.0)
 }
 
 /// Encodes and attempts to write a bool value into the given write.
@@ -101,92 +143,123 @@ pub fn write_nil<W: Write>(wr: &mut W) -> Result<(), Error> {
 /// Each call to this function may generate an I/O error indicating that the operation could not be
 /// completed.
 #[inline]
-pub fn write_bool<W: Write>(wr: &mut W, val: bool) -> Result<(), Error> {
+pub fn write_bool<W: RmpWrite>(wr: &mut W, val: bool) -> Result<(), W::Error> {
     let marker = if val { Marker::True } else { Marker::False };
 
-    write_marker(wr, marker).map_err(From::from)
+    write_marker(wr, marker).map_err(|e| e.0)
 }
 
-#[inline]
-fn write_data_u8<W: Write>(wr: &mut W, val: u8) -> Result<(), DataWriteError> {
-    wr.write_u8(val).map_err(DataWriteError)
+mod sealed{
+    pub trait Sealed {}
+    #[cfg(feature = "std")]
+    impl<T: ?Sized + std::io::Write> Sealed for T {}
+    impl Sealed for super::ByteBuf {}
 }
 
-#[inline]
-fn write_data_u16<W: Write>(wr: &mut W, val: u16) -> Result<(), DataWriteError> {
-    wr.write_u16::<byteorder::BigEndian>(val).map_err(DataWriteError)
+
+macro_rules! write_byteorder_utils {
+    ($($name:ident => $tp:ident),* $(,)?) => {
+        $(
+            #[inline]
+            #[doc(hidden)]
+            fn $name(&mut self, val: $tp) -> Result<(), DataWriteError<Self::Error>> where Self: Sized {
+                const SIZE: usize = core::mem::size_of::<$tp>();
+                let mut buf: [u8; SIZE] = [0u8; SIZE];
+                paste::paste! {
+                    byteorder::BigEndian::[<write_ $tp>](&mut buf, val);
+                }
+                self.write_bytes(&buf).map_err(DataWriteError)
+            }
+        )*
+    };
 }
 
-#[inline]
-fn write_data_u32<W: Write>(wr: &mut W, val: u32) -> Result<(), DataWriteError> {
-    wr.write_u32::<byteorder::BigEndian>(val).map_err(DataWriteError)
+/// A type that `rmp` supports writing into.
+///
+/// The methods of this trait should be considered an implementation detail (for now).
+///
+/// See also [std::io::Write] and [byteorder::WriteBytesExt]
+///
+/// It is only implemented for `std::io::Read` and `Bytes`.
+pub trait RmpWrite: sealed::Sealed {
+    type Error: RmpWriteErr;
+    /// Write a single byte to this stream
+    #[inline]
+    fn write_u8(&mut self, val: u8) -> Result<(), Self::Error> {
+        let buf = [val];
+        self.write_bytes(&buf)
+    }
+    /// Write a single (signed) byte to this type.
+    #[inline]
+    #[doc(hidden)]
+    fn write_data_u8(&mut self, val: u8) -> Result<(), DataWriteError<Self::Error>> {
+        self.write_u8(val).map_err(DataWriteError)
+    }
+    /// Write a single (signed) byte to this type.
+    #[inline]
+    #[doc(hidden)]
+    fn write_data_i8(&mut self, val: i8) -> Result<(), DataWriteError<Self::Error>> {
+        self.write_data_u8(val as u8)
+    }
+    /// Write a slice of bytes to the underlying stream
+    ///
+    /// This will either write all the bytes or return an error.
+    /// See also [std::io::Write::write_all]
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+    write_byteorder_utils!(
+        write_data_u16 => u16,
+        write_data_u32 => u32,
+        write_data_u64 => u64,
+        write_data_i16 => i16,
+        write_data_i32 => i32,
+        write_data_i64 => i64,
+        write_data_f32 => f32,
+        write_data_f64 => f64
+    );
 }
 
-#[inline]
-fn write_data_u64<W: Write>(wr: &mut W, val: u64) -> Result<(), DataWriteError> {
-    wr.write_u64::<byteorder::BigEndian>(val).map_err(DataWriteError)
-}
+#[cfg(feature = "std")]
+impl<T: std::io::Write> RmpWrite for T {
+    type Error = std::io::Error;
 
-#[inline]
-fn write_data_i8<W: Write>(wr: &mut W, val: i8) -> Result<(), DataWriteError> {
-    wr.write_i8(val).map_err(DataWriteError)
-}
-
-#[inline]
-fn write_data_i16<W: Write>(wr: &mut W, val: i16) -> Result<(), DataWriteError> {
-    wr.write_i16::<byteorder::BigEndian>(val).map_err(DataWriteError)
-}
-
-#[inline]
-fn write_data_i32<W: Write>(wr: &mut W, val: i32) -> Result<(), DataWriteError> {
-    wr.write_i32::<byteorder::BigEndian>(val).map_err(DataWriteError)
-}
-
-#[inline]
-fn write_data_i64<W: Write>(wr: &mut W, val: i64) -> Result<(), DataWriteError> {
-    wr.write_i64::<byteorder::BigEndian>(val).map_err(DataWriteError)
-}
-
-#[inline]
-fn write_data_f32<W: Write>(wr: &mut W, val: f32) -> Result<(), DataWriteError> {
-    wr.write_f32::<byteorder::BigEndian>(val).map_err(DataWriteError)
-}
-
-#[inline]
-fn write_data_f64<W: Write>(wr: &mut W, val: f64) -> Result<(), DataWriteError> {
-    wr.write_f64::<byteorder::BigEndian>(val).map_err(DataWriteError)
+    #[inline]
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.write_all(buf)
+    }
 }
 
 /// An error that can occur when attempting to write multi-byte MessagePack value.
 #[derive(Debug)]
-pub enum ValueWriteError {
+#[allow(deprecated)] // TODO: Needed for compatibility
+pub enum ValueWriteError<E: RmpWriteErr = Error> {
     /// I/O error while writing marker.
-    InvalidMarkerWrite(Error),
+    InvalidMarkerWrite(E),
     /// I/O error while writing data.
-    InvalidDataWrite(Error),
+    InvalidDataWrite(E),
 }
 
-impl From<MarkerWriteError> for ValueWriteError {
+impl<E: RmpWriteErr> From<MarkerWriteError<E>> for ValueWriteError<E> {
     #[cold]
-    fn from(err: MarkerWriteError) -> ValueWriteError {
+    fn from(err: MarkerWriteError<E>) -> Self {
         match err {
             MarkerWriteError(err) => ValueWriteError::InvalidMarkerWrite(err),
         }
     }
 }
 
-impl From<DataWriteError> for ValueWriteError {
+impl<E: RmpWriteErr> From<DataWriteError<E>> for ValueWriteError<E> {
     #[cold]
-    fn from(err: DataWriteError) -> ValueWriteError {
+    fn from(err: DataWriteError<E>) -> Self {
         match err {
             DataWriteError(err) => ValueWriteError::InvalidDataWrite(err),
         }
     }
 }
 
-impl From<ValueWriteError> for Error {
+#[cfg(feature = "std")] // Backwards compatbility ;)
+impl From<ValueWriteError<std::io::Error>> for std::io::Error {
     #[cold]
-    fn from(err: ValueWriteError) -> Error {
+    fn from(err: ValueWriteError<std::io::Error>) -> std::io::Error {
         match err {
             ValueWriteError::InvalidMarkerWrite(err) |
             ValueWriteError::InvalidDataWrite(err) => err,
@@ -194,7 +267,8 @@ impl From<ValueWriteError> for Error {
     }
 }
 
-impl error::Error for ValueWriteError {
+#[cfg(feature = "std")]
+impl<E: RmpWriteErr> error::Error for ValueWriteError<E> {
     #[cold]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
@@ -204,7 +278,7 @@ impl error::Error for ValueWriteError {
     }
 }
 
-impl Display for ValueWriteError {
+impl<E: RmpWriteErr> Display for ValueWriteError<E> {
     #[cold]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("error while writing multi-byte MessagePack value")
@@ -218,17 +292,17 @@ impl Display for ValueWriteError {
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_array_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError> {
+pub fn write_array_len<W: RmpWrite>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError<W::Error>> {
     let marker = if len < 16 {
         write_marker(wr, Marker::FixArray(len as u8))?;
         Marker::FixArray(len as u8)
-    } else if len < 65536 {
+    } else if len <= u16::MAX as u32 {
         write_marker(wr, Marker::Array16)?;
-        write_data_u16(wr, len as u16)?;
+        wr.write_data_u16(len as u16)?;
         Marker::Array16
     } else {
         write_marker(wr, Marker::Array32)?;
-        write_data_u32(wr, len)?;
+        wr.write_data_u32(len)?;
         Marker::Array32
     };
 
@@ -242,17 +316,17 @@ pub fn write_array_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWr
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_map_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError> {
+pub fn write_map_len<W: RmpWrite>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError<W::Error>> {
     let marker = if len < 16 {
         write_marker(wr, Marker::FixMap(len as u8))?;
         Marker::FixMap(len as u8)
-    } else if len < 65536 {
+    } else if len <= u16::MAX as u32 {
         write_marker(wr, Marker::Map16)?;
-        write_data_u16(wr, len as u16)?;
+        wr.write_data_u16(len as u16)?;
         Marker::Map16
     } else {
         write_marker(wr, Marker::Map32)?;
-        write_data_u32(wr, len)?;
+        wr.write_data_u32(len)?;
         Marker::Map32
     };
 
@@ -271,7 +345,7 @@ pub fn write_map_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWrit
 ///
 /// Panics if `ty` is negative, because it is reserved for future MessagePack extension including
 /// 2-byte type information.
-pub fn write_ext_meta<W: Write>(wr: &mut W, len: u32, ty: i8) -> Result<Marker, ValueWriteError> {
+pub fn write_ext_meta<W: RmpWrite>(wr: &mut W, len: u32, ty: i8) -> Result<Marker, ValueWriteError<W::Error>> {
     let marker = match len {
         1 => {
             write_marker(wr, Marker::FixExt1)?;
@@ -295,22 +369,22 @@ pub fn write_ext_meta<W: Write>(wr: &mut W, len: u32, ty: i8) -> Result<Marker, 
         }
         len if len < 256 => {
             write_marker(wr, Marker::Ext8)?;
-            write_data_u8(wr, len as u8)?;
+            wr.write_data_u8(len as u8)?;
             Marker::Ext8
         }
         len if len < 65536 => {
             write_marker(wr, Marker::Ext16)?;
-            write_data_u16(wr, len as u16)?;
+            wr.write_data_u16(len as u16)?;
             Marker::Ext16
         }
         len => {
             write_marker(wr, Marker::Ext32)?;
-            write_data_u32(wr, len)?;
+            wr.write_data_u32(len)?;
             Marker::Ext32
         }
     };
 
-    write_data_i8(wr, ty)?;
+    wr.write_data_i8(ty)?;
 
     Ok(marker)
 }

--- a/rmp/src/encode/str.rs
+++ b/rmp/src/encode/str.rs
@@ -1,6 +1,4 @@
-use std::io::Write;
-
-use super::{write_data_u16, write_data_u32, write_data_u8, write_marker};
+use super::{RmpWrite, write_marker};
 use crate::encode::ValueWriteError;
 use crate::Marker;
 
@@ -11,21 +9,21 @@ use crate::Marker;
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_str_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError> {
+pub fn write_str_len<W: RmpWrite>(wr: &mut W, len: u32) -> Result<Marker, ValueWriteError<W::Error>> {
     if len < 32 {
         write_marker(wr, Marker::FixStr(len as u8))?;
         Ok(Marker::FixStr(len as u8))
     } else if len < 256 {
         write_marker(wr, Marker::Str8)?;
-        write_data_u8(wr, len as u8)?;
+        wr.write_data_u8(len as u8)?;
         Ok(Marker::Str8)
-    } else if len < 65536 {
+    } else if len <= u16::MAX as u32 {
         write_marker(wr, Marker::Str16)?;
-        write_data_u16(wr, len as u16)?;
+        wr.write_data_u16(len as u16)?;
         Ok(Marker::Str16)
     } else {
         write_marker(wr, Marker::Str32)?;
-        write_data_u32(wr, len)?;
+        wr.write_data_u32(len)?;
         Ok(Marker::Str32)
     }
 }
@@ -38,7 +36,7 @@ pub fn write_str_len<W: Write>(wr: &mut W, len: u32) -> Result<Marker, ValueWrit
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
 // TODO: Docs, range check, example, visibility.
-pub fn write_str<W: Write>(wr: &mut W, data: &str) -> Result<(), ValueWriteError> {
+pub fn write_str<W: RmpWrite>(wr: &mut W, data: &str) -> Result<(), ValueWriteError<W::Error>> {
     write_str_len(wr, data.len() as u32)?;
-    wr.write_all(data.as_bytes()).map_err(ValueWriteError::InvalidDataWrite)
+    wr.write_bytes(data.as_bytes()).map_err(ValueWriteError::InvalidDataWrite)
 }

--- a/rmp/src/encode/uint.rs
+++ b/rmp/src/encode/uint.rs
@@ -1,7 +1,5 @@
-use std::io::Write;
-
-use super::{write_data_u16, write_data_u32, write_data_u64, write_data_u8, write_marker};
-use crate::encode::{Error, ValueWriteError};
+use super::{RmpWrite, write_marker};
+use crate::encode::{ValueWriteError};
 use crate::Marker;
 
 /// Encodes and attempts to write an unsigned small integer value as a positive fixint into the
@@ -25,9 +23,9 @@ use crate::Marker;
 ///
 /// Panics if `val` is greater than 127.
 #[inline]
-pub fn write_pfix<W: Write>(wr: &mut W, val: u8) -> Result<(), Error> {
+pub fn write_pfix<W: RmpWrite>(wr: &mut W, val: u8) -> Result<(), W::Error> {
     assert!(val < 128);
-    write_marker(wr, Marker::FixPos(val))?;
+    write_marker(wr, Marker::FixPos(val)).map_err(|e| e.0)?;
     Ok(())
 }
 
@@ -57,9 +55,9 @@ pub fn write_pfix<W: Write>(wr: &mut W, val: u8) -> Result<(), Error> {
 /// rmp::encode::write_u8(&mut &mut buf[..], 42).ok().unwrap();
 /// assert_eq!([0xcc, 0x2a], buf);
 /// ```
-pub fn write_u8<W: Write>(wr: &mut W, val: u8) -> Result<(), ValueWriteError> {
+pub fn write_u8<W: RmpWrite>(wr: &mut W, val: u8) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::U8)?;
-    write_data_u8(wr, val)?;
+    wr.write_data_u8(val)?;
     Ok(())
 }
 
@@ -77,9 +75,9 @@ pub fn write_u8<W: Write>(wr: &mut W, val: u8) -> Result<(), ValueWriteError> {
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_u16<W: Write>(wr: &mut W, val: u16) -> Result<(), ValueWriteError> {
+pub fn write_u16<W: RmpWrite>(wr: &mut W, val: u16) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::U16)?;
-    write_data_u16(wr, val)?;
+    wr.write_data_u16(val)?;
     Ok(())
 }
 
@@ -97,9 +95,9 @@ pub fn write_u16<W: Write>(wr: &mut W, val: u16) -> Result<(), ValueWriteError> 
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_u32<W: Write>(wr: &mut W, val: u32) -> Result<(), ValueWriteError> {
+pub fn write_u32<W: RmpWrite>(wr: &mut W, val: u32) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::U32)?;
-    write_data_u32(wr, val)?;
+    wr.write_data_u32(val)?;
     Ok(())
 }
 
@@ -117,9 +115,9 @@ pub fn write_u32<W: Write>(wr: &mut W, val: u32) -> Result<(), ValueWriteError> 
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_u64<W: Write>(wr: &mut W, val: u64) -> Result<(), ValueWriteError> {
+pub fn write_u64<W: RmpWrite>(wr: &mut W, val: u64) -> Result<(), ValueWriteError<W::Error>> {
     write_marker(wr, Marker::U64)?;
-    write_data_u64(wr, val)?;
+    wr.write_data_u64(val)?;
     Ok(())
 }
 
@@ -136,7 +134,7 @@ pub fn write_u64<W: Write>(wr: &mut W, val: u64) -> Result<(), ValueWriteError> 
 ///
 /// This function will return `ValueWriteError` on any I/O error occurred while writing either the
 /// marker or the data.
-pub fn write_uint<W: Write>(wr: &mut W, val: u64) -> Result<Marker, ValueWriteError> {
+pub fn write_uint<W: RmpWrite>(wr: &mut W, val: u64) -> Result<Marker, ValueWriteError<W::Error>> {
     if val < 128 {
         write_pfix(wr, val as u8)
             .and(Ok(Marker::FixPos(val as u8)))

--- a/rmp/src/lib.rs
+++ b/rmp/src/lib.rs
@@ -147,7 +147,11 @@
 //! ```
 //!
 //! [read_int]: decode/fn.read_int.html
+#![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+#[cfg(feature = "std")]
 pub mod decode;
 pub mod encode;
 mod marker;


### PR DESCRIPTION
Because std::io::Write is missing from the `core` crate,
this introduces our own `RmpWrite` trait (and a ByteBuf type).

I plan to do something similar for RmpRead.

For no\_std targets, the only implementation of RmpWrite/RmpRead is for our
own ByteBuf/Bytes type. This is inspired by `serde_bytes` (see here

When #[cfg(feature="std")] is enabled (the default), then
RmpWrite has a blanket implementation for std::io::Write.
This makes it is 100% backwards compatible.

Because of this, introducing this trait required 0 changes to the tests or the dependent crates.

Because of this careful backwards compatibility, these changes should only
require a patch version bump for the `rmp` crate (we are major version 0).

This also moves several (internal) utility methods to RmpWrite.
Further refactoring should be possible in the future.

TODO:
- [ ] Implement no\_std decoding (that shouldn't even require the alloc crate)
- [ ] Tests for no\_std (right now I just assume passing std tests imply passing `no_std` support)
- [ ] patch version bump

Before I work on any of this, I'd like your opinions on this. `#[no_std]` support is definitely useful for those of us trying to optimize binary size 😉 