### PR TITLE
with_struct_map for Deserializer

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -14,7 +14,7 @@ use rmp;
 use rmp::decode::{self, RmpRead, DecodeStringError, MarkerReadError, NumValueReadError, ValueReadError};
 use rmp::Marker;
 
-use crate::config::{BinaryConfig, DefaultConfig, HumanReadableConfig, SerializerConfig};
+use crate::config::{BinaryConfig, DefaultConfig, HumanReadableConfig, SerializerConfig, StructMapConfig};
 use crate::MSGPACK_EXT_STRUCT_NAME;
 
 /// Enum representing errors that can occur while decoding MessagePack data.

--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -256,6 +256,19 @@ impl<R: Read, C: SerializerConfig> Deserializer<R, C> {
             depth,
         }
     }
+
+    /// Consumes this deserializer and returns a new one, which will deserialize types with
+    /// struct map representations.
+    #[inline]
+    pub fn with_struct_map(self) -> Deserializer<R, StructMapConfig<C>> {
+        let Deserializer { rd, config, marker, depth } = self;
+        Deserializer {
+            rd,
+            config: StructMapConfig::new(config),
+            marker,
+            depth,
+        }
+    }
 }
 
 impl<R: AsRef<[u8]>> Deserializer<ReadReader<Cursor<R>>> {


### PR DESCRIPTION
```rust
#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
struct RPC_PASSTHRU_MSG {
    ProtocolID: u32,
    RxStatus: u32,
    TxFlags: u32,
    Timestamp: u32,
    DataSize: u32,
    ExtraDataIndex: u32,
    Data: Vec<u8>
}

#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
struct PassThruStartMsgFilterRequest {
    channelId: u32,
    filterType: u32,
    maskMsg: RPC_PASSTHRU_MSG, <-- trying to get this as an object/hashmap
    patternMsg: RPC_PASSTHRU_MSG, <-- trying to get this as an object/hashmap
    flowControlMsg: RPC_PASSTHRU_MSG, <-- trying to get this as an object/hashmap
}

```