### PR TITLE
Fix SeqAccess and MapAccess unchecked unused length; float deserialize simplification

### DIFF
--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -679,55 +679,11 @@ impl<'de, 'a, R: ReadSlice<'de>, C: SerializerConfig> serde::Deserializer<'de> f
         visitor.visit_u128(u128::from_be_bytes(buf))
     }
 
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
-    {
-        // This special case allows us to decode some integer types as floats when safe, and
-        // asked for.
-        //
-        // This allows interoperability with msgpack-lite, which performs an optimization of
-        // storing rounded floats as integers.
-        let f = match self.take_or_read_marker()? {
-            Marker::U8 => self.rd.read_data_u8().map(f32::from),
-            Marker::U16 => self.rd.read_data_u16().map(f32::from),
-            Marker::I8 => self.rd.read_data_i8().map(f32::from),
-            Marker::I16 => self.rd.read_data_i16().map(f32::from),
-            Marker::F32 => self.rd.read_data_f32(),
-            marker => {
-                self.marker = Some(marker);
-                return self.deserialize_any(visitor);
-            }
-        }?;
-        visitor.visit_f32(f)
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-        where V: Visitor<'de>
-    {
-        // This special case allows us to decode some integer types as floats when safe, and
-        // asked for. This is here to be consistent with 'f32'.
-        let f = match self.take_or_read_marker()? {
-            Marker::U8 => self.rd.read_data_u8().map(f64::from),
-            Marker::U16 => self.rd.read_data_u16().map(f64::from),
-            Marker::U32 => self.rd.read_data_u32().map(f64::from),
-            Marker::I8 => self.rd.read_data_i8().map(f64::from),
-            Marker::I16 => self.rd.read_data_i16().map(f64::from),
-            Marker::I32 => self.rd.read_data_i32().map(f64::from),
-            Marker::F32 => self.rd.read_data_f32().map(f64::from),
-            Marker::F64 => self.rd.read_data_f64(),
-            marker => {
-                self.marker = Some(marker);
-                return self.deserialize_any(visitor);
-            }
-        }?;
-        visitor.visit_f64(f)
-    }
-
     forward_to_deserialize_any! {
-        bool u8 u16 u32 u64 i8 i16 i32 i64 char
-        str string bytes byte_buf unit seq map
-        struct identifier tuple tuple_struct
-        ignored_any
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32
+        f64 char str string bytes byte_buf unit
+        seq map struct identifier tuple
+        tuple_struct ignored_any
     }
 }
 

--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -148,7 +148,7 @@ impl Raw {
     pub fn as_err(&self) -> Option<&Utf8Error> {
         match self.s {
             Ok(..) => None,
-            Err((_, ref err)) => Some(&err),
+            Err((_, ref err)) => Some(err),
         }
     }
 
@@ -294,7 +294,7 @@ impl<'a> RawRef<'a> {
     #[inline]
     pub fn as_str(&self) -> Option<&str> {
         match self.s {
-            Ok(ref s) => Some(s),
+            Ok(s) => Some(s),
             Err(..) => None,
         }
     }
@@ -305,7 +305,7 @@ impl<'a> RawRef<'a> {
     pub fn as_err(&self) -> Option<&Utf8Error> {
         match self.s {
             Ok(..) => None,
-            Err((_, ref err)) => Some(&err),
+            Err((_, ref err)) => Some(err),
         }
     }
 
@@ -313,8 +313,8 @@ impl<'a> RawRef<'a> {
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         match self.s {
-            Ok(ref s) => s.as_bytes(),
-            Err(ref err) => &err.0[..],
+            Ok(s) => s.as_bytes(),
+            Err((bytes, _err)) => bytes,
         }
     }
 }


### PR DESCRIPTION
Fixes #287: currently, the serde deserializer doesn't check the lengths of MapAccess or SeqAccess objects it sends to `visit_seq` and `visit_map`. This leads to a problem where certain kinds of input deserialize incorrectly. Added a fix for this bug, as well as a regression test demonstrating it.

Fixes #303: There's no reason to have a complex custom float deserializer when floats already successfully deserialize themselves from ints.

Additionally, made some obvious fixes suggested by `cargo check` and `cargo clippy`