### PR TITLE
docs(rmp-serde): update example to use from_slice

### DIFF
--- a/rmp-serde/src/lib.rs
+++ b/rmp-serde/src/lib.rs
@@ -12,7 +12,7 @@
 //!     buf
 //! );
 //!
-//! assert_eq!((42, "the Answer"), rmp_serde::from_read_ref(&buf).unwrap());
+//! assert_eq!((42, "the Answer"), rmp_serde::from_slice(&buf).unwrap());
 //! ```
 //!
 //! # Type-based Serialization and Deserialization


### PR DESCRIPTION
I just updated from v0.14 to v1.1.1 and updated uses of the deprecated fn `from_read_ref` to `from_slice`. When checking the docs for an updated format of encoding, I saw the example still uses `from_read_ref`. I suggest to update to `from_slice`.