### PR TITLE
Remove byteorder dependency

### DIFF
--- a/rmp-serde/Cargo.toml
+++ b/rmp-serde/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2021"
 tag-prefix = "{{crate_name}}/"
 
 [dependencies]
-byteorder = "1.4.3"
 serde = "1.0.136"
 rmp = { version = "0.8.11", path = "../rmp" }
 

--- a/rmp-serde/src/decode.rs
+++ b/rmp-serde/src/decode.rs
@@ -7,8 +7,6 @@ use std::io::{self, Cursor, ErrorKind, Read};
 use std::num::TryFromIntError;
 use std::str::{self, Utf8Error};
 
-use byteorder::{self, ReadBytesExt};
-
 use serde;
 use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, Unexpected, Visitor};
 
@@ -362,17 +360,24 @@ fn read_bin_data<'a, 'de, R: ReadSlice<'de>>(rd: &'a mut R, len: u32) -> Result<
 }
 
 fn read_u8<R: Read>(rd: &mut R) -> Result<u8, Error> {
-    byteorder::ReadBytesExt::read_u8(rd).map_err(Error::InvalidDataRead)
+    let mut data = [0; 1];
+    rd.read_exact(&mut data)
+        .map_err(Error::InvalidDataRead)?;
+    Ok(u8::from_be_bytes(data))
 }
 
 fn read_u16<R: Read>(rd: &mut R) -> Result<u16, Error> {
-    rd.read_u16::<byteorder::BigEndian>()
-        .map_err(Error::InvalidDataRead)
+    let mut data = [0; 2];
+    rd.read_exact(&mut data)
+        .map_err(Error::InvalidDataRead)?;
+    Ok(u16::from_be_bytes(data))
 }
 
 fn read_u32<R: Read>(rd: &mut R) -> Result<u32, Error> {
-    rd.read_u32::<byteorder::BigEndian>()
-        .map_err(Error::InvalidDataRead)
+    let mut data = [0; 4];
+    rd.read_exact(&mut data)
+        .map_err(Error::InvalidDataRead)?;
+    Ok(u32::from_be_bytes(data))
 }
 
 fn ext_len<R: Read>(rd: &mut R, marker: Marker) -> Result<u32, Error> {

--- a/rmp/Cargo.toml
+++ b/rmp/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["encoding"]
 edition = "2021"
 
 [dependencies]
-byteorder = { version = "1.4.2", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 # This is macro_only ;)
 paste = "1.0"
@@ -20,7 +19,7 @@ paste = "1.0"
 
 [features]
 default = ["std"]
-std = ["byteorder/std", "num-traits/std"]
+std = ["num-traits/std"]
 
 [dev-dependencies]
 quickcheck = "1.0.2"

--- a/rmp/src/decode/mod.rs
+++ b/rmp/src/decode/mod.rs
@@ -58,9 +58,7 @@ macro_rules! read_byteorder_utils {
                 const SIZE: usize = core::mem::size_of::<$tp>();
                 let mut buf: [u8; SIZE] = [0u8; SIZE];
                 self.read_exact_buf(&mut buf).map_err(ValueReadError::InvalidDataRead)?;
-                Ok(paste::paste! {
-                    <byteorder::BigEndian as byteorder::ByteOrder>::[<read_ $tp>](&mut buf)
-                })
+                Ok($tp::from_be_bytes(buf))
             }
         )*
     };
@@ -80,7 +78,7 @@ mod sealed{
 /// The methods of this trait should be considered an implementation detail (for now).
 /// It is currently sealed (can not be implemented by the user).
 ///
-/// See also [std::io::Read] and [byteorder::ReadBytesExt]
+/// See also [std::io::Read]
 ///
 /// Its primary implementations are [std::io::Read] and [Bytes].
 pub trait RmpRead: sealed::Sealed {

--- a/rmp/src/encode/mod.rs
+++ b/rmp/src/encode/mod.rs
@@ -122,12 +122,7 @@ macro_rules! write_byteorder_utils {
             #[inline]
             #[doc(hidden)]
             fn $name(&mut self, val: $tp) -> Result<(), DataWriteError<Self::Error>> where Self: Sized {
-                const SIZE: usize = core::mem::size_of::<$tp>();
-                let mut buf: [u8; SIZE] = [0u8; SIZE];
-                paste::paste! {
-                    <byteorder::BigEndian as byteorder::ByteOrder>::[<write_ $tp>](&mut buf, val);
-                }
-                self.write_bytes(&buf).map_err(DataWriteError)
+                self.write_bytes(&val.to_be_bytes()).map_err(DataWriteError)
             }
         )*
     };
@@ -138,7 +133,7 @@ macro_rules! write_byteorder_utils {
 /// The methods of this trait should be considered an implementation detail (for now).
 /// It is currently sealed (can not be implemented by the user).
 ///
-/// See also [std::uo::Write] and [byteorder::WriteBytesExt]
+/// See also [std::uo::Write]
 ///
 /// Its primary implementations are [std::io::Write] and [ByteBuf].
 pub trait RmpWrite: sealed::Sealed {


### PR DESCRIPTION
I feel like the byteorder crate does not do much useful here and can easily be removed. This is what this PR does.