### PR TITLE
qualify lifetime on `Utf8ResultRef::as_bytes` result

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -367,7 +367,7 @@ impl<'a> Utf8StringRef<'a> {
 
     /// Returns a byte slice of this string contents no matter whether it's valid or not UTF-8.
     #[inline]
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &'a [u8] {
         match self.s {
             Ok(s) => s.as_bytes(),
             Err(ref err) => err.0,


### PR DESCRIPTION
Without this, you can't write something like:

```rust
fn read_slice_ref<'a, R: value_ref::BorrowRead<'a>>(r: &mut R) -> Option<&'a [u8]> {
    match value_ref::read_value_ref(r).ok()? {
        rmpv::ValueRef::Binary(v) => Some(v),
        rmpv::ValueRef::String(u) => Some(u.as_bytes()),
        _ => None,
    }
}
```

because the compiler (version 1.72) complains:

```
error[E0515]: cannot return value referencing local variable `u`
   --> src/main.rs:124:38
    |
124 |         rmpv::ValueRef::String(u) => Some(u.as_bytes()),
    |                                      ^^^^^------------^
    |                                      |    |
    |                                      |    `u` is borrowed here
    |                                      returns a value referencing data owned by the current function
```

With this PR, things work as one would expect.