### PR TITLE
Add rmpv::ext::to_value_named to keep struct keys

### DIFF
--- a/rmpv/src/ext/mod.rs
+++ b/rmpv/src/ext/mod.rs
@@ -7,6 +7,7 @@ use crate::{IntPriv, Integer, Value, ValueRef};
 
 pub use self::de::{deserialize_from, from_value, EnumRefDeserializer};
 pub use self::se::to_value;
+pub use self::se::to_value_named;
 
 mod de;
 mod se;


### PR DESCRIPTION
The current `rmpv::ext::to_value` implementation turns Structs into `Value::Array<Value::String>` which is not deserializable by other languages.

Technically I would call this a bug and opt to change the existing `to_value` implementation, but to stay cautious of not breaking existing users' code I think it makes sense to introduce a new `to_value_named` fn which instead turns Structs into `Value::Map` and maintains their keys.

Fixes #190