### PR TITLE
Add heapless-backed ByteBuf

### DIFF
--- a/rmp/Cargo.toml
+++ b/rmp/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = { version = "1.4.2", default-features = false }
+heapless = { version = "0.7.16", optional = true }
 num-traits = { version = "0.2.14", default-features = false }
 # This is macro_only ;)
 paste = "1.0"
@@ -20,7 +21,9 @@ paste = "1.0"
 
 [features]
 default = ["std"]
-std = ["byteorder/std", "num-traits/std"]
+alloc = []
+heapless = ["dep:heapless"]
+std = ["alloc", "byteorder/std", "num-traits/std"]
 
 [dev-dependencies]
 quickcheck = "1.0.2"

--- a/rmp/src/encode/mod.rs
+++ b/rmp/src/encode/mod.rs
@@ -110,9 +110,14 @@ mod sealed{
     impl<T: ?Sized + std::io::Write> Sealed for T {}
     #[cfg(not(feature = "std"))]
     impl Sealed for &mut [u8] {}
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
     impl Sealed for alloc::vec::Vec<u8> {}
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
     impl Sealed for super::ByteBuf {}
+    #[cfg(all(feature = "heapless", not(feature = "std")))]
+    impl<const N: usize> Sealed for heapless::Vec<u8, N> {}
+    #[cfg(all(feature = "heapless", not(feature = "std")))]
+    impl<const N: usize> Sealed for super::ByteBuf<N> {}
 }
 
 

--- a/rmp/src/lib.rs
+++ b/rmp/src/lib.rs
@@ -149,6 +149,7 @@
 //! [read_int]: decode/fn.read_int.html
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature="alloc")]
 extern crate alloc;
 
 pub mod decode;


### PR DESCRIPTION
Use of alloc crate is now behind a feature

Still missing proper error handling, but I wanted to get an idea if this would be a potentially accepted PR before putting in too much effort.