### PR TITLE
fix TypeMismatch error description

### DIFF
--- a/rmp/CHANGELOG.md
+++ b/rmp/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Needed because `std::io::Read` (and Write) are missing on `#![no_std]`
 - Introduces new `Bytes` and `ByteBuf` wrappers, that implement RmpRead/RmpWrite for no\_std targets.
 
+### Fixed
+- Fixed grammar in `TypeMismatch` error messages.
+
 ## 0.8.6 - 2017-04-23
 ### Added
 - New `rmp::decode::read_str_from_slice` function for zero-copy reading strings from slices.

--- a/rmp/src/decode/mod.rs
+++ b/rmp/src/decode/mod.rs
@@ -219,7 +219,7 @@ impl Display for ValueReadError {
             ValueReadError::InvalidMarkerRead(..) => "failed to read MessagePack marker",
             ValueReadError::InvalidDataRead(..) => "failed to read MessagePack data",
             ValueReadError::TypeMismatch(..) => {
-                "the type decoded isn't match with the expected one"
+                "the type decoded does not match the expected one"
             }
         })
     }
@@ -327,7 +327,7 @@ impl<E: RmpReadErr> Display for NumValueReadError<E> {
             NumValueReadError::InvalidMarkerRead(..) => "failed to read MessagePack marker",
             NumValueReadError::InvalidDataRead(..) => "failed to read MessagePack data",
             NumValueReadError::TypeMismatch(..) => {
-                "the type decoded isn't match with the expected one"
+                "the type decoded does not match the expected one"
             }
             NumValueReadError::OutOfRange => "out of range integral type conversion attempted",
         })


### PR DESCRIPTION
Minor grammar fix for `ValueReadError::TypeMismatch` and `NumValueReadError::TypeMismatch` error descriptions