### PR TITLE
Gate `est` tests behind the `std` feature

### DIFF
--- a/rmp/tests/func/est.rs
+++ b/rmp/tests/func/est.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use rmp::Marker;
 use rmp::decode::MessageLen;
 use rmp::decode::LenError;


### PR DESCRIPTION
`est` features are tied to the `std` feature, so the tests should be gated accordingly too