### PR TITLE
Relax lifetimes returned by methods of `Utf8StringRef`

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -354,7 +354,7 @@ impl<'a> Utf8StringRef<'a> {
     /// Returns the string reference if the string is valid UTF-8, or else `None`.
     #[inline]
     #[must_use]
-    pub fn as_str(&self) -> Option<&str> {
+    pub fn as_str(&self) -> Option<&'a str> {
         self.s.ok()
     }
 
@@ -372,7 +372,7 @@ impl<'a> Utf8StringRef<'a> {
     /// Returns a byte slice of this string contents no matter whether it's valid or not UTF-8.
     #[inline]
     #[must_use]
-    pub const fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &'a [u8] {
         match self.s {
             Ok(s) => s.as_bytes(),
             Err(ref err) => err.0,


### PR DESCRIPTION
Previously, `Utf8StringRef::as_bytes` and some other methods returned references with lifetime bound to `&self`, while the actual reference lifetime is `'a`.

With this change, a function life this could now be written:

```
fn extract_bytes<'a>(value: rmpv::ValueRef<'a>) -> &'a [u8] {
    match auth_request {
        rmpv::ValueRef::String(s) => s.as_bytes(),
        rmpv::ValueRef::Binary(s) => s,
        _ => panic!(),
    }
}
```