### PR TITLE
docs: correct DefaultConfig enum variant serialization description

### DIFF
--- a/rmp-serde/src/config.rs
+++ b/rmp-serde/src/config.rs
@@ -87,7 +87,7 @@ impl sealed::SerializerConfig for RuntimeConfig {
 ///
 /// This configuration:
 /// - Writes structs as a tuple, without field names
-/// - Writes enum variants as integers
+/// - Writes enum variants by their name, as a string
 /// - Writes and reads types as binary, not human-readable
 ///
 /// This is the most compact representation.


### PR DESCRIPTION
Fixes #323.

The `DefaultConfig` doc comment says it "Writes enum variants as integers", but the serializer writes the variant name as a string. The `serialize_*_variant` methods in `encode.rs` ignore the variant index (`_: u32`) and call `self.serialize_str(variant)` on the variant identifier. Updated the description to match the implementation.