### PR TITLE
Implement `From<bool>` for `ValueRef`

### DIFF
--- a/rmpv/src/lib.rs
+++ b/rmpv/src/lib.rs
@@ -1367,6 +1367,13 @@ impl ValueRef<'_> {
     }
 }
 
+impl From<bool> for ValueRef<'_> {
+    #[inline]
+    fn from(v: bool) -> Self {
+        Self::Boolean(v)
+    }
+}
+
 impl From<u8> for ValueRef<'_> {
     #[inline]
     fn from(v: u8) -> Self {

--- a/rmpv/tests/decode_ref.rs
+++ b/rmpv/tests/decode_ref.rs
@@ -16,7 +16,7 @@ fn from_bool_false() {
 
     let mut rd = &buf[..];
 
-    assert_eq!(ValueRef::Boolean(false), read_value_ref(&mut rd).unwrap());
+    assert_eq!(ValueRef::from(false), read_value_ref(&mut rd).unwrap());
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn from_bool_true() {
 
     let mut rd = &buf[..];
 
-    assert_eq!(ValueRef::Boolean(true), read_value_ref(&mut rd).unwrap());
+    assert_eq!(ValueRef::from(true), read_value_ref(&mut rd).unwrap());
 }
 
 #[test]
@@ -596,7 +596,7 @@ fn get_complex_msgpack_value<'a>() -> ValueRef<'a> {
             (
                 ValueRef::from("map"),
                 ValueRef::Array(vec![
-                    ValueRef::Boolean(true),
+                    ValueRef::from(true),
                     ValueRef::Map(vec![(
                         ValueRef::from(42),
                         ValueRef::from(100500),
@@ -659,7 +659,7 @@ fn into_owned() {
             (
                 Value::from("map"),
                 Value::Array(vec![
-                    Value::Boolean(true),
+                    Value::from(true),
                     Value::Map(vec![(Value::from(42), Value::from(100500))]),
                 ]),
             ),

--- a/rmpv/tests/encode_ref.rs
+++ b/rmpv/tests/encode_ref.rs
@@ -28,7 +28,7 @@ fn pack_nil_when_buffer_is_tool_small() {
 fn pass_pack_true() {
     let mut buf = [0x00];
 
-    let val = ValueRef::Boolean(true);
+    let val = ValueRef::from(true);
 
     write_value_ref(&mut &mut buf[..], &val).unwrap();
 


### PR DESCRIPTION
`Value` implements `From<bool>` so we can pass booleans to functions like below.

```rust
fn send_some_value(value: impl Into<Value>) {
  // ...
}

send_some_value(true);
```

However `ValueRef` doesn't implement it.

```rust
fn send_some_value_ref(value: impl Into<ValueRef<'_>>) {
  // ...
}

send_some_value_ref(true); // ERROR
```

I believe there is no reason not to implement it so I created this PR to add the conversion.